### PR TITLE
Upgrade ubuntu to xenial in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ branches:
     - master
     # Version tags.
     - /^v?\d+\.\d+.*$/
-    - xenial_test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      dist: trusty
-      compiler: gcc-5
+      dist: xenial
+      compiler: gcc-7
       addons:
         apt:
           sources:
@@ -13,10 +13,11 @@ matrix:
           packages:
             - build-essential
             - coreutils
-            - gcc-5
-            - g++-5
-            - python3.4
-            - python3.4-venv
+            - gcc-7
+            - g++-7
+            - pandoc
+            - python3.5
+            - python3.5-venv
             - cmake
             - flex
             - bison
@@ -63,6 +64,7 @@ branches:
     - master
     # Version tags.
     - /^v?\d+\.\d+.*$/
+    - xenial_test
 
 notifications:
   email:

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -39,4 +39,5 @@ else
 fi
 
 source "${SCRIPT_DIR}/use_env.sh"
+pip install wheel
 pip install -r "${SCRIPT_DIR}/requirements.txt"


### PR DESCRIPTION
With this change, we can upgrade Python to version 3.5 and also gcc to version 7 (because of upcoming C++17 requirement).

Could you Petr please review the changes if it's ok? Thanks.

