### PR TITLE
Doxygen: Generate documentation from header files.

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           = doxygen.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../src
+INPUT                  = ../src ../include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           = doxygen.log
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../src ../include
+INPUT                  = ../src ../include ../tests
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Currently the doxygen documentation is generated only from files in `src/` directory.
Files in `include/` have valid doxygen documentation but are not processed. Because of this classes like `RegexpUnit` are missing from generated documentation.

Retdec does something similar: https://github.com/avast/retdec/blob/master/doc/doxygen/doxygen.cfg.in#L828