### PR TITLE
Parse pog fixes

### DIFF
--- a/include/yaramod/types/literal.h
+++ b/include/yaramod/types/literal.h
@@ -20,6 +20,8 @@ namespace yaramod {
 
 class Symbol;
 
+enum TextFormat{Raw, Pure, RawWithoutQuotes};
+
 /**
  * Class representing literal. Literal can be either
  * string, integer or boolean. This class can only bear
@@ -102,8 +104,9 @@ public:
 
 	/// @name String representation
 	/// @{
-	std::string getText(bool pure = false) const;
+	std::string getText(TextFormat = Raw) const;
 	std::string getPureText() const;
+	std::string getTextWithoutQuotes() const;
 	/// @}
 
 	/// @name Detection methods

--- a/include/yaramod/types/token.h
+++ b/include/yaramod/types/token.h
@@ -182,8 +182,9 @@ public:
 
 	/// @name String representation
 	/// @{
-	std::string getText() const {	return _value->getText(); }
+	std::string getText() const { return _value->getText(); }
 	std::string getPureText() const { return _value->getPureText(); }
+	std::string getTextWithoutQuotes() const { return _value->getTextWithoutQuotes(); }
 	/// @}
 
 	/// @name Setter methods

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -161,22 +161,22 @@ void ParserDriver::defineTokens()
 	//$include_file end
 
 	_parser.token(R"(0x[0-9a-fA-F]+)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		int64_t n;
+		int64_t n = 0;
 		strToNum(std::string{str}, n, std::hex);
 		return emplace_back(INTEGER, n, std::make_optional(std::string{str}));
 	});
 	_parser.token(R"([0-9]+KB)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		int64_t n;
+		int64_t n = 0;
 		strToNum(std::string{str}.substr(0, str.size()-2), n);
 		return emplace_back(INTEGER, 1000 * n, std::make_optional(std::string{str}));
 	});
 	_parser.token(R"([0-9]+MB)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		int64_t n;
+		int64_t n = 0;
 		strToNum(std::string{str}.substr(0, str.size()-2), n);
 		return emplace_back(INTEGER, 1000000 * n, std::make_optional(std::string{str}));
 	});
 	_parser.token(R"([0-9]+)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		int64_t n;
+		int64_t n = 0;
 		strToNum(std::string{str}, n);
 		return emplace_back(INTEGER, n, std::make_optional(std::string{str}));
 	});

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -161,16 +161,24 @@ void ParserDriver::defineTokens()
 	//$include_file end
 
 	_parser.token(R"(0x[0-9a-fA-F]+)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		return emplace_back(INTEGER, static_cast<int64_t>(std::stol(std::string{str}.substr(2), 0, 16)), std::make_optional(std::string{str}));
+		int64_t n;
+		strToNum(std::string{str}, n, std::hex);
+		return emplace_back(INTEGER, n, std::make_optional(std::string{str}));
 	});
 	_parser.token(R"([0-9]+KB)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		return emplace_back(INTEGER, 1000 * static_cast<int64_t>(std::stol(std::string{str})), std::make_optional(std::string{str}));
+		int64_t n;
+		strToNum(std::string{str}.substr(0, str.size()-2), n);
+		return emplace_back(INTEGER, 1000 * n, std::make_optional(std::string{str}));
 	});
 	_parser.token(R"([0-9]+MB)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		return emplace_back(INTEGER, 1000000 * static_cast<int64_t>(std::stol(std::string{str})), std::make_optional(std::string{str}));
+		int64_t n;
+		strToNum(std::string{str}.substr(0, str.size()-2), n);
+		return emplace_back(INTEGER, 1000000 * n, std::make_optional(std::string{str}));
 	});
 	_parser.token(R"([0-9]+)").symbol("INTEGER").description("integer").action([&](std::string_view str) -> Value {
-		return emplace_back(INTEGER, static_cast<int64_t>(std::stol(std::string{str})), std::make_optional(std::string{str}));
+		int64_t n;
+		strToNum(std::string{str}, n);
+		return emplace_back(INTEGER, n, std::make_optional(std::string{str}));
 	});
 
 	_parser.token(R"(\/\/[^\n]*)").states("@default", "$hexstr", "@hexstr_jump").action([&](std::string_view str) -> Value {

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -205,7 +205,11 @@ void ParserDriver::defineTokens()
 		_comment.append(std::string{str});
 		return {};
 	});
-	_parser.token(R"(.)").states("$multiline_comment").action([&](std::string_view str) -> Value {
+	_parser.token(R"([^\n*]*)").states("$multiline_comment").action([&](std::string_view str) -> Value {
+		_comment.append(std::string{str});
+		return {};
+	});
+	_parser.token(R"(\*)").states("$multiline_comment").action([&](std::string_view str) -> Value {
 		_comment.append(std::string{str});
 		return {};
 	});

--- a/src/types/literal.cpp
+++ b/src/types/literal.cpp
@@ -194,8 +194,12 @@ std::string Literal::getFormattedValue() const
 }
 
 /**
- * Returns the string representation of the literal in the form it was created in, enclosed in double quotes.
+ * Returns the string representation of the literal in a specified format:
  *
+ * @param format:
+ *     Raw  -  in the form it was created in, enclosed in double quotes.
+ *     RawWithoutQuotes  -  in the form it was created in, without quotes.
+ *     Pure  -  unescaped text without quotes
  * @return String representation.
  */
 std::string Literal::getText(TextFormat format/* = Raw*/) const
@@ -271,7 +275,7 @@ std::string Literal::getPureText() const
 }
 
 /**
- * Returns the string representation readable, so instead of '\x40' prints '@', instead of '\x0a' or '\n' prints new line.
+ * Returns the string in the exact form it was written in.
  *
  * @return String representation.
  */

--- a/src/types/literal.cpp
+++ b/src/types/literal.cpp
@@ -198,15 +198,17 @@ std::string Literal::getFormattedValue() const
  *
  * @return String representation.
  */
-std::string Literal::getText(bool pure) const
+std::string Literal::getText(TextFormat format/* = Raw*/) const
 {
 	if (is<std::string>())
 	{
 		const std::string& output = get<std::string>();
-		if (pure)
+		if (format == Pure)
 			return unescapeString(output);
-		else
+		else if(format == Raw)
 			return '"' + output + '"';
+		else
+			return output;
 	}
 	else if (is<bool>())
 	{
@@ -265,7 +267,17 @@ std::string Literal::getText(bool pure) const
  */
 std::string Literal::getPureText() const
 {
-	return getText(true);
+	return getText(Pure);
+}
+
+/**
+ * Returns the string representation readable, so instead of '\x40' prints '@', instead of '\x0a' or '\n' prints new line.
+ *
+ * @return String representation.
+ */
+std::string Literal::getTextWithoutQuotes() const
+{
+	return getText(RawWithoutQuotes);
 }
 
 bool Literal::isIntegral() const

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -405,8 +405,7 @@ std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenS
 	}
 
 	if (ss)
-		for (const auto& c : it->getPureText())
-			*ss << c;
+		*ss << it->getTextWithoutQuotes();
 	return columnCounter;
 }
 


### PR DESCRIPTION
This PR brings two fixes of our POG based parser:

- Use strToNum instead of std::stol, because stol would make us troubles on Windows, where long is signed and has usually only 32 bits.
- Comments are printed as were written.