### PR TITLE
Parse pog fixes

### DIFF
--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -366,6 +366,7 @@ private:
 	std::string _regexpClass; ///< Currently processed regular expression class.
 	pog::Parser<Value> _parser; ///< used pog parser
 	bool _sectionStrings = false; ///< flag used to determine if we parse section after 'strings:'
+	bool _escapedContent = false; ///< flag used to determine if a currently parsed literal contains hexadecimal byte (such byte must be unescaped in getPureText())
 
 	ParserMode _mode; ///< Parser mode.
 

--- a/include/yaramod/types/literal.h
+++ b/include/yaramod/types/literal.h
@@ -20,8 +20,6 @@ namespace yaramod {
 
 class Symbol;
 
-enum TextFormat{Raw, Pure, RawWithoutQuotes};
-
 /**
  * Class representing literal. Literal can be either
  * string, integer or boolean. This class can only bear
@@ -65,6 +63,8 @@ public:
 	void setValue(double f, const std::optional<std::string>& integral_formated_value = std::nullopt);
 	void setValue(const std::shared_ptr<Symbol>& s, const std::string& symbol_name);
 	void setValue(std::shared_ptr<Symbol>&& s, std::string&& symbol_name);
+
+	void markEscaped() {  _escaped = true; }
 	/// @}
 
 	/// @name Getter methods
@@ -104,9 +104,8 @@ public:
 
 	/// @name String representation
 	/// @{
-	std::string getText(TextFormat = Raw) const;
+	std::string getText(bool pure = false) const;
 	std::string getPureText() const;
-	std::string getTextWithoutQuotes() const;
 	/// @}
 
 	/// @name Detection methods
@@ -135,6 +134,7 @@ public:
 	}
 
 private:
+	bool _escaped = false;
 	/// For an integral literal x there are two options:
 	/// i.  x it is unformatted:	_formated_value is empty  AND  _value contains x
 	/// ii. x it is formatted:	  _formated_value contains x's string representation  AND  _value contains pure x

--- a/include/yaramod/types/token.h
+++ b/include/yaramod/types/token.h
@@ -184,7 +184,6 @@ public:
 	/// @{
 	std::string getText() const { return _value->getText(); }
 	std::string getPureText() const { return _value->getPureText(); }
-	std::string getTextWithoutQuotes() const { return _value->getTextWithoutQuotes(); }
 	/// @}
 
 	/// @name Setter methods
@@ -205,6 +204,7 @@ public:
 	void setFlag(bool flag) { _flag = flag; }
 	void setLocation(const Location& location) { _location = location; }
 	void setIndentation(std::size_t wanted_column) { _wanted_column = wanted_column; }
+	void markEscaped() { _value->markEscaped(); }
 	/// @}
 
 	/// @name Detection methods

--- a/src/builder/yara_expression_builder.cpp
+++ b/src/builder/yara_expression_builder.cpp
@@ -733,6 +733,7 @@ YaraExpressionBuilder stringVal(const std::string& value)
 {
 	auto ts = std::make_shared<TokenStream>();
 	TokenIt token = ts->emplace_back(STRING_LITERAL, escapeString(value));
+	token->markEscaped();
 	auto expression = std::make_shared<StringLiteralExpression>(token);
 	return YaraExpressionBuilder(std::move(ts), std::move(expression), Expression::Type::String);
 }

--- a/src/builder/yara_rule_builder.cpp
+++ b/src/builder/yara_rule_builder.cpp
@@ -185,6 +185,7 @@ YaraRuleBuilder& YaraRuleBuilder::withStringMeta(const std::string& key, const s
 	auto itKey = _tokenStream->emplace(insert_before, TokenType::META_KEY, key);
 	_tokenStream->emplace(insert_before, TokenType::ASSIGN, "=");
 	auto itValue = _tokenStream->emplace(insert_before, TokenType::META_VALUE, escapeString(value));
+	itValue->markEscaped();
 	_tokenStream->emplace(insert_before, TokenType::NEW_LINE, "\n");
 
 	_metas.emplace_back(itKey, itValue);

--- a/src/types/literal.cpp
+++ b/src/types/literal.cpp
@@ -196,23 +196,18 @@ std::string Literal::getFormattedValue() const
 /**
  * Returns the string representation of the literal in a specified format:
  *
- * @param format:
- *     Raw  -  in the form it was created in, enclosed in double quotes.
- *     RawWithoutQuotes  -  in the form it was created in, without quotes.
- *     Pure  -  unescaped text without quotes
+ * @param pure Flag only used for string literals. If set, the exact form this was created in is returned -- without quotes.
  * @return String representation.
  */
-std::string Literal::getText(TextFormat format/* = Raw*/) const
+std::string Literal::getText(bool pure/* = false*/) const
 {
 	if (is<std::string>())
 	{
-		const std::string& output = get<std::string>();
-		if (format == Pure)
-			return unescapeString(output);
-		else if(format == Raw)
-			return '"' + output + '"';
+		const auto& output = get<std::string>();
+		if (pure)
+			return _escaped ? unescapeString(output) : output;
 		else
-			return output;
+			return '"' + output + '"';
 	}
 	else if (is<bool>())
 	{
@@ -265,23 +260,13 @@ std::string Literal::getText(TextFormat format/* = Raw*/) const
 }
 
 /**
- * Returns the string representation readable, so instead of '\x40' prints '@', instead of '\x0a' or '\n' prints new line.
+ * Returns the string in the exact form it was written in.
  *
  * @return String representation.
  */
 std::string Literal::getPureText() const
 {
-	return getText(Pure);
-}
-
-/**
- * Returns the string in the exact form it was written in.
- *
- * @return String representation.
- */
-std::string Literal::getTextWithoutQuotes() const
-{
-	return getText(RawWithoutQuotes);
+	return getText(true);
 }
 
 bool Literal::isIntegral() const

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -405,7 +405,7 @@ std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenS
 	}
 
 	if (ss)
-		*ss << it->getTextWithoutQuotes();
+		*ss << it->getPureText();
 	return columnCounter;
 }
 
@@ -462,8 +462,10 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 			else
 				helper.insertIntoStream(os, this, it);
 		}
-		else if ((current == ONELINE_COMMENT || current == COMMENT))
+		else if (current == ONELINE_COMMENT || current == COMMENT)
+		{
 			helper.printComment(os, this, it, alignComments);
+		}
 		else
 			helper.insertIntoStream(os, this, it);
 

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -387,25 +387,25 @@ std::size_t TokenStream::PrintHelper::insertIntoStream(std::stringstream* ss, To
 std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenStream* ts, TokenIt it, bool alignComment)
 {
 	auto prevIt = ts->predecessor(it);
+	auto indentation = it->getIndentation() + 1;
 
 	const std::string& indent = it->getLiteral().getFormattedValue();
-	// print indent part 1
-	if (prevIt && (*prevIt)->getType() == NEW_LINE)
+	// Comment at a beginning of a line
+	if(ss)
 	{
-		if (ss)
+		if (!prevIt || (*prevIt)->getType() == NEW_LINE)
+		{
 			*ss << indent;
-	}// print indent part 2
-	else if (ss && alignComment && columnCounter < it->getIndentation() && (!prevIt || (*prevIt)->getType() != COLON))
-		*ss << std::string(it->getIndentation() - columnCounter + 1, ' ');
-	// remember oneline comments
-	if (it->getType() == ONELINE_COMMENT && (!prevIt || (*prevIt)->getType() != COLON))
+		}
+		else if(alignComment && columnCounter < indentation && (!prevIt || (*prevIt)->getType() != COLON))
+			*ss << std::string(indentation - columnCounter, ' ');
+		*ss << it->getPureText();
+	}
+	else if(it->getType() == ONELINE_COMMENT && (!prevIt || (*prevIt)->getType() != COLON))
 	{
 		commentOnThisLine = true;
 		commentPool.push_back(it);
 	}
-
-	if (ss)
-		*ss << it->getPureText();
 	return columnCounter;
 }
 

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4086,5 +4086,94 @@ rule rule1 {
 	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
 
+TEST_F(ParserTests,
+AutoformattingNewlines) {
+	prepareInput(
+R"(/*
+This is a comment at the beginning
+*/
+
+rule cruel_rule
+{
+	meta:
+		author = "Mr. Avastien"
+		description = "reliability_test"
+		reliability = "brief" // comment
+		strain = "Krakonos"  // comment
+		type = "roof"  // comment
+		severity = "virus"    // comment
+		hash = "596EAF3CDD47A710743016E0C032A6EFD0922BA3010C899277E80AA6B6226F85"    // comment
+		rule_type = "typical" // comment
+	strings:
+		$h00 = {
+				b8 17 ?? 01
+				b8 17 ?? 02
+				b8 17 ?? 03 04 //COMMENTARY 1
+				b8 17 ?? 23 55       //COMMENTARY 1
+				b8 17 ?? 24 a1 //COMMENTARY 1
+				b8 17 ?? 25 b5 c6 c1 //COMMENTARY 1
+				b8 17 ?? 35
+				b8 17 ?? 36 04 //COMMENTARY 2
+				b8 17 ?? 37 05 06 //COMMENTARY 2
+				b8 17 ?? 47 07 //COMMENTARY 2
+				b8 17 ?? 48
+				b8 17 ?? 49 11 //COMMENTARY 3
+				b8 17 ?? 57 //COMMENTARY 3
+				b8 17 ?? 58
+				} // 0x00000852 preparing bytes for sending semi-valid SMB response
+		$s00 = "str 123" // 0x17
+		$s01 = "string 234567"  // 0x005
+		$s02 = "basic for loop" // 0
+	condition:
+		any of ($s0*) or
+		$h00
+})");
+	EXPECT_TRUE(driver.parse());
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+std::string expected = R"(/*
+This is a comment at the beginning
+*/
+
+rule cruel_rule
+{
+	meta:
+		author = "Mr. Avastien"
+		description = "reliability_test"
+		reliability = "brief"                                                     // comment
+		strain = "Krakonos"                                                       // comment
+		type = "roof"                                                             // comment
+		severity = "virus"                                                        // comment
+		hash = "596EAF3CDD47A710743016E0C032A6EFD0922BA3010C899277E80AA6B6226F85" // comment
+		rule_type = "typical"                                                     // comment
+	strings:
+		$h00 = {
+			b8 17 ?? 01
+			b8 17 ?? 02
+			b8 17 ?? 03 04       //COMMENTARY 1
+			b8 17 ?? 23 55       //COMMENTARY 1
+			b8 17 ?? 24 a1       //COMMENTARY 1
+			b8 17 ?? 25 b5 c6 c1 //COMMENTARY 1
+			b8 17 ?? 35
+			b8 17 ?? 36 04    //COMMENTARY 2
+			b8 17 ?? 37 05 06 //COMMENTARY 2
+			b8 17 ?? 47 07    //COMMENTARY 2
+			b8 17 ?? 48
+			b8 17 ?? 49 11 //COMMENTARY 3
+			b8 17 ?? 57    //COMMENTARY 3
+			b8 17 ?? 58
+		}                       // 0x00000852 preparing bytes for sending semi-valid SMB response
+		$s00 = "str 123"        // 0x17
+		$s01 = "string 234567"  // 0x005
+		$s02 = "basic for loop" // 0
+	condition:
+		any of ($s0*) or
+		$h00
+})";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+
 }
 }


### PR DESCRIPTION
This PR contains fixes of our pog-based parser.

- Use strToNum instead of std::stol to avoid overflow
- The `escapeString` and `unescapeString` methods are used to store literals as written in the rule. This PR reduces their usage only to places where necessary.
- A few more small fixes of code style.