### PR TITLE
Autoformat adds \r or \n depending on newlines used in the file.

### DIFF
--- a/include/yaramod/types/expressions.h
+++ b/include/yaramod/types/expressions.h
@@ -1194,8 +1194,9 @@ public:
 	{
 	}
 
-	IdExpression(TokenIt symbol)
-		: _symbol(symbol->getSymbol())
+	IdExpression(TokenIt symbolToken)
+		: _symbol(symbolToken->getSymbol())
+		, _symbolToken(symbolToken)
 	{
 	}
 
@@ -1215,8 +1216,16 @@ public:
 		return _symbol;
 	}
 
+	void setSymbol(const std::shared_ptr<Symbol>& symbol)
+	{
+		_symbol = symbol;
+		if (_symbolToken)
+			_symbolToken.value()->setValue(_symbol, _symbol->getName());
+	}
+
 protected:
 	std::shared_ptr<Symbol> _symbol; ///< Symbol of the identifier
+	std::optional<TokenIt> _symbolToken; ///< Token of the 
 };
 
 /**

--- a/include/yaramod/types/token_stream.h
+++ b/include/yaramod/types/token_stream.h
@@ -125,8 +125,8 @@ public:
 
 	/// @name New Line Characters
 	/// @{
-	char getNewLineChar() const { return new_line_char; }
-	void setNewLineChar(char c) { new_line_char = c; }
+	const std::string& getNewLineStyle() const { return new_line_style; }
+	void setNewLineChar(std::string line) { new_line_style = std::move(line); }
 	/// @}
 
 	/// @name Reseting method
@@ -142,7 +142,7 @@ protected:
 private:
 	std::list<Token> _tokens; ///< All tokens off the rule
 	bool formatted = false; ///< The flag is set once autoformat has been called
-	char new_line_char = '\n'; ///< The character used for line endings: usually '\n' on Unix or '\r' on Windows
+	std::string new_line_style = "\n"; ///< The character used for line endings: usually '\n' on Unix or '\r' on MacOs or '\r\n' on Windows
 };
 
 } //namespace yaramod

--- a/include/yaramod/types/token_stream.h
+++ b/include/yaramod/types/token_stream.h
@@ -123,6 +123,12 @@ public:
 	std::vector<std::string> getTokensAsText() const;
 	/// @}
 
+	/// @name New Line Characters
+	/// @{
+	char getNewLineChar() const { return new_line_char; }
+	void setNewLineChar(char c) { new_line_char = c; }
+	/// @}
+
 	/// @name Reseting method
 	void clear();
 	/// @}
@@ -136,6 +142,7 @@ protected:
 private:
 	std::list<Token> _tokens; ///< All tokens off the rule
 	bool formatted = false; ///< The flag is set once autoformat has been called
+	char new_line_char = '\n'; ///< The character used for line endings: usually '\n' on Unix or '\r' on Windows
 };
 
 } //namespace yaramod

--- a/include/yaramod/types/token_stream.h
+++ b/include/yaramod/types/token_stream.h
@@ -125,8 +125,8 @@ public:
 
 	/// @name New Line Characters
 	/// @{
-	const std::string& getNewLineStyle() const { return new_line_style; }
-	void setNewLineChar(std::string line) { new_line_style = std::move(line); }
+	const std::string& getNewLineStyle() const { return _new_line_style; }
+	void setNewLineChar(std::string line) { _new_line_style = std::move(line); }
 	/// @}
 
 	/// @name Reseting method
@@ -141,8 +141,8 @@ protected:
 	std::optional<TokenIt> predecessor(TokenIt it);
 private:
 	std::list<Token> _tokens; ///< All tokens off the rule
-	bool formatted = false; ///< The flag is set once autoformat has been called
-	std::string new_line_style = "\n"; ///< The character used for line endings: usually '\n' on Unix or '\r' on MacOs or '\r\n' on Windows
+	bool _formatted = false; ///< The flag is set once autoformat has been called
+	std::string _new_line_style = "\n"; ///< The character used for line endings: usually '\n' on Unix or '\r' on MacOs or '\r\n' on Windows
 };
 
 } //namespace yaramod

--- a/src/builder/yara_expression_builder.cpp
+++ b/src/builder/yara_expression_builder.cpp
@@ -10,8 +10,6 @@
 #include "yaramod/types/symbols.h"
 #include "yaramod/utils/utils.h"
 
-#include <iostream>
-
 namespace yaramod {
 
 namespace {

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -36,14 +36,14 @@ void ParserDriver::defineTokens()
 		currentLocation().addColumn(str.length());
 	});
 
-	_parser.token("[\n\r]").action([&](std::string_view str) -> Value {
-		currentTokenStream()->setNewLineChar(std::string{str}.front());
+	_parser.token("\r\n|\r|\n").action([&](std::string_view str) -> Value {
+		currentTokenStream()->setNewLineChar(std::string{str});
 		TokenIt t = emplace_back(NEW_LINE, std::string{str});
 		_indent.clear();
 		currentLocation().addLine();
 		return t;
 	});
-	_parser.token("[ \t]+").states("@default", "$hexstr_jump", "$hexstr").action([&](std::string_view str) -> Value { // spaces, tabulators, carrige-returns
+	_parser.token("[ \t]+").states("@default", "$hexstr_jump", "$hexstr").action([&](std::string_view str) -> Value { // spaces, tabulators
 		_indent += std::string{str};
 		return {};
 	});
@@ -140,9 +140,9 @@ void ParserDriver::defineTokens()
 	_parser.token("include").symbol("INCLUDE_DIRECTIVE").description("include").enter_state("$include").action([&](std::string_view str) -> Value {
 		return emplace_back(INCLUDE_DIRECTIVE, std::string{str});
 	});
-	_parser.token("[\n\r]").states("$include").action([&](std::string_view str) -> Value {
+	_parser.token("\r\n|\r|\n").states("$include").action([&](std::string_view str) -> Value {
 		currentLocation().addLine();
-		currentTokenStream()->setNewLineChar(std::string{str}.front());
+		currentTokenStream()->setNewLineChar(std::string{str});
 		return Value(emplace_back(NEW_LINE, std::string{str}));
 	});
 	_parser.token(R"([ \v\r\t])").states("$include");
@@ -303,7 +303,7 @@ void ParserDriver::defineTokens()
 	_parser.token(R"({[ \v\r\t]}*)").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value { return {}; });;
 	_parser.token(R"([\n])").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value {
 		currentLocation().addLine();
-		return emplace_back(NEW_LINE, currentTokenStream()->getNewLineChar());
+		return emplace_back(NEW_LINE, currentTokenStream()->getNewLineStyle());
 	});
 	_parser.token(R"(\s)").states("$hexstr", "@hexstr_jump");
 	// $hexstr end

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -303,6 +303,7 @@ void ParserDriver::defineTokens()
 	_parser.token(R"({[ \v\r\t]}*)").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value { return {}; });;
 	_parser.token(R"([\n])").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value {
 		currentLocation().addLine();
+		_indent.clear();
 		return emplace_back(NEW_LINE, currentTokenStream()->getNewLineStyle());
 	});
 	_parser.token(R"(\s)").states("$hexstr", "@hexstr_jump");

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -36,7 +36,7 @@ void ParserDriver::defineTokens()
 		currentLocation().addColumn(str.length());
 	});
 
-	_parser.token("\r\n|\r|\n").action([&](std::string_view str) -> Value {
+	_parser.token("\r\n|\n").action([&](std::string_view str) -> Value {
 		currentTokenStream()->setNewLineChar(std::string{str});
 		TokenIt t = emplace_back(NEW_LINE, std::string{str});
 		_indent.clear();
@@ -140,12 +140,12 @@ void ParserDriver::defineTokens()
 	_parser.token("include").symbol("INCLUDE_DIRECTIVE").description("include").enter_state("$include").action([&](std::string_view str) -> Value {
 		return emplace_back(INCLUDE_DIRECTIVE, std::string{str});
 	});
-	_parser.token("\r\n|\r|\n").states("$include").action([&](std::string_view str) -> Value {
+	_parser.token("\r\n|\n").states("$include").action([&](std::string_view str) -> Value {
 		currentLocation().addLine();
 		currentTokenStream()->setNewLineChar(std::string{str});
 		return Value(emplace_back(NEW_LINE, std::string{str}));
 	});
-	_parser.token(R"([ \v\r\t])").states("$include");
+	_parser.token(R"([ \v\t])").states("$include");
 	_parser.token(R"(\")").states("$include").enter_state("$include_file");
 	//$include_file
 	_parser.token(R"([^"]+\")").symbol("INCLUDE_FILE").description("include path").states("$include_file").enter_state("@default").action([&](std::string_view str) -> Value {
@@ -300,7 +300,7 @@ void ParserDriver::defineTokens()
 	});
 	// $hexstr multiline comment end
 
-	_parser.token(R"({[ \v\r\t]}*)").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value { return {}; });;
+	_parser.token(R"({[ \v\t]}*)").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value { return {}; });;
 	_parser.token(R"([\n])").states("$hexstr", "@hexstr_jump").action([&](std::string_view) -> Value {
 		currentLocation().addLine();
 		_indent.clear();

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -364,7 +364,9 @@ void addExpressionClasses(py::module& module)
 				&RangeExpression::getHigh,
 				py::overload_cast<const Expression::Ptr&>(&RangeExpression::setHigh));
 	exprClass<IdExpression>(module, "IdExpression")
-		.def_property_readonly("symbol", &IdExpression::getSymbol);
+		.def_property("symbol",
+				&IdExpression::getSymbol,
+				&IdExpression::setSymbol);
 	exprClass<StructAccessExpression, IdExpression>(module, "StructAccessExpression")
 		.def_property("structure",
 				&StructAccessExpression::getStructure,

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -305,7 +305,7 @@ void TokenStream::addMissingNewLines()
 			brackets.addLeftBracket(lineCounter, it->getFlag());
 			if (brackets.putNewlineInCurrentSector() && next != NEW_LINE && next != ONELINE_COMMENT && next != COMMENT)
 			{
-				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_style);
+				nextIt = emplace(nextIt, TokenType::NEW_LINE, _new_line_style);
 				next = nextIt->getType();
 			}
 		}
@@ -313,7 +313,7 @@ void TokenStream::addMissingNewLines()
 		{
 			if (brackets.putNewlineInCurrentSector() && current != NEW_LINE)
 			{
-				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_style);
+				nextIt = emplace(nextIt, TokenType::NEW_LINE, _new_line_style);
 				next = nextIt->getType();
 			}
 			else
@@ -328,7 +328,7 @@ void TokenStream::autoformat()
 {
 	determineNewlineSectors();
 	addMissingNewLines();
-	formatted = true;
+	_formatted = true;
 }
 
 std::size_t TokenStream::PrintHelper::insertIntoStream(std::stringstream* ss, char what)
@@ -434,7 +434,7 @@ std::string TokenStream::getText(bool withIncludes, bool alignComments)
  */
 void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, bool withIncludes, bool alignComments)
 {
-	if (!formatted)
+	if (!_formatted)
 		autoformat();
 	BracketStack brackets;
 	int current_line_tabs = 0;

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -305,7 +305,7 @@ void TokenStream::addMissingNewLines()
 			brackets.addLeftBracket(lineCounter, it->getFlag());
 			if (brackets.putNewlineInCurrentSector() && next != NEW_LINE && next != ONELINE_COMMENT && next != COMMENT)
 			{
-				nextIt = emplace(nextIt, TokenType::NEW_LINE, "\n");
+				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_char);
 				next = nextIt->getType();
 			}
 		}
@@ -313,7 +313,7 @@ void TokenStream::addMissingNewLines()
 		{
 			if (brackets.putNewlineInCurrentSector() && current != NEW_LINE)
 			{
-				nextIt = emplace(nextIt, TokenType::NEW_LINE, "\n");
+				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_char);
 				next = nextIt->getType();
 			}
 			else

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -590,7 +590,7 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 		}
 		else if (inside_enumeration_brackets)
 		{
-			if (current != LP_ENUMERATION && next != RP_ENUMERATION && next != COMMA)
+			if (current != LP_ENUMERATION && next != RP_ENUMERATION && next != COMMA && next != NEW_LINE)
 				helper.insertIntoStream(os, ' ');
 		}
 		else if (current == HEX_ALT_RIGHT_BRACKET || current == HEX_ALT_LEFT_BRACKET)

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -305,7 +305,7 @@ void TokenStream::addMissingNewLines()
 			brackets.addLeftBracket(lineCounter, it->getFlag());
 			if (brackets.putNewlineInCurrentSector() && next != NEW_LINE && next != ONELINE_COMMENT && next != COMMENT)
 			{
-				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_char);
+				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_style);
 				next = nextIt->getType();
 			}
 		}
@@ -313,7 +313,7 @@ void TokenStream::addMissingNewLines()
 		{
 			if (brackets.putNewlineInCurrentSector() && current != NEW_LINE)
 			{
-				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_char);
+				nextIt = emplace(nextIt, TokenType::NEW_LINE, new_line_style);
 				next = nextIt->getType();
 			}
 			else

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4244,6 +4244,43 @@ rule cruel_rule
 }
 
 TEST_F(ParserTests,
+AutoformattingCommentInsideHexstringOnNewline) {
+	prepareInput(
+R"(rule cruel_rule
+{
+	strings:
+		$h00 = {
+			// comment inside hex on the beginning
+			b8 17 ?? 01
+			// comment inside hex in the middle
+			b8 17 ?? 03 04
+			b8 17 ?? 23 55
+			// comment inside hex in the end
+			}
+	condition:
+		true
+})");
+	EXPECT_TRUE(driver.parse());
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+std::string expected = R"(rule cruel_rule
+{
+	strings:
+		$h00 = {
+			// comment inside hex on the beginning
+			b8 17 ?? 01
+			// comment inside hex in the middle
+			b8 17 ?? 03 04
+			b8 17 ?? 23 55
+			// comment inside hex in the end
+		}
+	condition:
+		true
+})";
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 AutoformattingOfOnelineRule) {
 	prepareInput(
 R"(rule oneline_rule { /*COMMENT*/ meta: author = "Mr. Avastien"    /*COMMENT*/    description = "reliability_test"    /*COMMENT*/      strings: $s00 = "str 123"     /*COMMENT*/    $s01 = "string 234567"   /*COMMENT*/    condition:   any of ($s0*) /*COMMENT*/ })");
@@ -4254,7 +4291,6 @@ std::string expected = R"(rule oneline_rule { /*COMMENT*/ meta: author = "Mr. Av
 
 	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
-
 
 TEST_F(ParserTests,
 CuckooScheduledTaskModuleFunction) {

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3968,7 +3968,7 @@ rule public_rule {
 }
 
 TEST_F(ParserTests,
-AutoformattingAddCRLF) {
+AutoformattingAddCR) {
 	prepareInput(
 "import \"cuckoo\"\r\rrule public_rule {\r	condition:\r		false or\r		(true and\r			(\r				true or\r				false\r				))\r}");
 	EXPECT_TRUE(driver.parse());
@@ -3976,6 +3976,19 @@ AutoformattingAddCRLF) {
 
 	std::string expected =
 "import \"cuckoo\"\r\rrule public_rule {\r	condition:\r		false or\r		(\r			true and\r			(\r				true or\r				false\r			)\r		)\r}";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+AutoformattingAddCRLF) {
+	prepareInput(
+"import \"cuckoo\"\r\n\r\nrule public_rule {\r\n	condition:\r\n		false or\r\n		(true and\r\n			(\r\n				true or\r\n				false\r\n				))\r\n}");
+	EXPECT_TRUE(driver.parse());
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	std::string expected =
+"import \"cuckoo\"\r\n\r\nrule public_rule {\r\n	condition:\r\n		false or\r\n		(\r\n			true and\r\n			(\r\n				true or\r\n				false\r\n			)\r\n		)\r\n}";
 
 	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3968,6 +3968,19 @@ rule public_rule {
 }
 
 TEST_F(ParserTests,
+AutoformattingAddCRLF) {
+	prepareInput(
+"import \"cuckoo\"\r\rrule public_rule {\r	condition:\r		false or\r		(true and\r			(\r				true or\r				false\r				))\r}");
+	EXPECT_TRUE(driver.parse());
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	std::string expected =
+"import \"cuckoo\"\r\rrule public_rule {\r	condition:\r		false or\r		(\r			true and\r			(\r				true or\r				false\r			)\r		)\r}";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 AutoformattingNoSpaceBeforeArrayAccess) {
 	prepareInput(
 R"(
@@ -4216,8 +4229,6 @@ rule cruel_rule
 
 	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
-
-
 
 TEST_F(ParserTests,
 AutoformattingOfOnelineRule) {

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4367,6 +4367,46 @@ std::string expected = R"(rule cruel_rule
 }
 
 TEST_F(ParserTests,
+AutoformattingNoSpaceBeforeNewLine) {
+	prepareInput(
+R"(import "math"
+
+rule rule1
+{
+	condition:
+		true and
+		(
+			for any i in (	1, 2, 3,
+									4, 5, 6,
+									7 ):
+		(
+			true)
+		)
+})");
+	EXPECT_TRUE(driver.parse());
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+std::string expected = R"(import "math"
+
+rule rule1
+{
+	condition:
+		true and
+		(
+			for any i in (
+				1, 2, 3,
+				4, 5, 6,
+				7
+			) :
+			(
+				true
+			)
+		)
+})";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+TEST_F(ParserTests,
 AutoformattingOfOnelineRule) {
 	prepareInput(
 R"(rule oneline_rule { /*COMMENT*/ meta: author = "Mr. Avastien"    /*COMMENT*/    description = "reliability_test"    /*COMMENT*/      strings: $s00 = "str 123"     /*COMMENT*/    $s01 = "string 234567"   /*COMMENT*/    condition:   any of ($s0*) /*COMMENT*/ })");


### PR DESCRIPTION
Bugfix of issue #48: We insert LF or CR or CRLF depending on what is used in the file, more precisely which of the three line endings `\n`, `\r` or `\r\n` has been used last time.