### PR TITLE
Update symbols

### DIFF
--- a/include/yaramod/builder/yara_file_builder.h
+++ b/include/yaramod/builder/yara_file_builder.h
@@ -36,9 +36,7 @@ class YaraFileBuilder
 public:
 	/// @name Constructors
 	/// @{
-	YaraFileBuilder() : YaraFileBuilder(ImportFeatures::All) {}
-
-	YaraFileBuilder(ImportFeatures features)
+	YaraFileBuilder(ImportFeatures features = ImportFeatures::All)
 		: _tokenStream(std::make_shared<TokenStream>())
 		, _import_features(features)
 	{

--- a/include/yaramod/types/yara_file.h
+++ b/include/yaramod/types/yara_file.h
@@ -22,8 +22,8 @@ class YaraFile
 public:
 	/// @name Constructors
 	/// @{
-	YaraFile();
-	YaraFile(const std::shared_ptr<TokenStream>& tokenStream);
+	YaraFile(ImportFeatures features = ImportFeatures::All);
+	YaraFile(const std::shared_ptr<TokenStream>& tokenStream, ImportFeatures features = ImportFeatures::All);
 	YaraFile(YaraFile&&) noexcept;
 
 	YaraFile& operator=(YaraFile&&) noexcept;
@@ -37,12 +37,12 @@ public:
 
 	/// @name Addition methods
 	/// @{
-	bool addImport(TokenIt import, ImportFeatures features, ModulesPool& modules);
+	bool addImport(TokenIt import, ModulesPool& modules);
 	void addRule(Rule&& rule);
 	void addRule(std::unique_ptr<Rule>&& rule);
 	void addRule(const std::shared_ptr<Rule>& rule);
 	void addRules(const std::vector<std::shared_ptr<Rule>>& rules);
-	bool addImports(const std::vector<TokenIt>& imports, ImportFeatures features, ModulesPool& modules);
+	bool addImports(const std::vector<TokenIt>& imports, ModulesPool& modules);
 	void insertRule(std::size_t position, std::unique_ptr<Rule>&& rule);
 	void insertRule(std::size_t position, const std::shared_ptr<Rule>& rule);
 	/// @}
@@ -77,7 +77,7 @@ public:
 
 	/// @name Symbol methods
 	/// @{
-	std::shared_ptr<Symbol> findSymbol(const std::string& name, ImportFeatures features) const;
+	std::shared_ptr<Symbol> findSymbol(const std::string& name) const;
 	/// @}
 
 	/// @name Detection methods
@@ -88,6 +88,8 @@ public:
 	/// @}
 
 private:
+	void initializeVTSymbols();
+
 	std::shared_ptr<TokenStream> _tokenStream; ///< tokenStream containing all the data in this Rule
 	std::vector<std::shared_ptr<Module>> _imports; ///< Imported modules
 	std::vector<std::shared_ptr<Rule>> _rules; ///< Rules
@@ -95,7 +97,8 @@ private:
 	std::unordered_map<std::string, Module*> _importTable;
 	std::unordered_map<std::string, Rule*> _ruleTable;
 
-	static const std::vector<std::shared_ptr<Symbol>> globalVariables; ///< Global variables
+	ImportFeatures _importFeatures; ///< Determines which symbols are needed
+	std::vector<std::shared_ptr<Symbol>> _vtSymbols; ///< Virust Total symbols
 };
 
 }

--- a/include/yaramod/yaramod.h
+++ b/include/yaramod/yaramod.h
@@ -33,8 +33,10 @@ public:
 	 * @param ParserMode
 	 * Regular -- regular YARA parser
 	 * IncludeGuarded -- protection against inclusion of the same file multiple times
+	 *
+	 * @param features determines iff we want to use aditional Avast-specific symbols or VirusTotal-specific symbols in the imported modules
 	 */
-	Yaramod() : _driver(ParserMode::Regular) {}
+	Yaramod(ImportFeatures features = ImportFeatures::All) : _driver(ParserMode::Regular, features) {}
 	/**
 	 * Parses file at given path.
 	 *

--- a/src/builder/yara_file_builder.cpp
+++ b/src/builder/yara_file_builder.cpp
@@ -19,8 +19,8 @@ namespace yaramod {
  */
 std::unique_ptr<YaraFile> YaraFileBuilder::get(bool recheck, ParserDriver* external_driver)
 {
-	auto yaraFile = std::make_unique<YaraFile>(std::move(_tokenStream));
-	yaraFile->addImports(_module_tokens, _import_features, _modules_pool);
+	auto yaraFile = std::make_unique<YaraFile>(std::move(_tokenStream), _import_features);
+	yaraFile->addImports(_module_tokens, _modules_pool);
 	yaraFile->addRules(_rules);
 
 	_module_tokens.clear();

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -418,7 +418,7 @@ void ParserDriver::defineGrammar()
 		.production("IMPORT_KEYWORD", "STRING_LITERAL", [&](auto&& args) -> Value {
 			TokenIt import = args[1].getTokenIt();
 			import->setType(IMPORT_MODULE);
-			if (!_file.addImport(import, _import_features, _modules))
+			if (!_file.addImport(import, _modules))
 				error_handle(import->getLocation(), "Unrecognized module '" + import->getString() + "' imported");
 			return {};
 		})
@@ -1591,7 +1591,7 @@ ParserDriver::ParserDriver(const std::string& filePath, ParserMode parserMode, I
 	_locations.emplace();
 	if (!includeFileImpl(filePath))
 		_valid = false;
-	_file = YaraFile(currentTokenStream());
+	_file = YaraFile(currentTokenStream(), _import_features);
 }
 
 /**
@@ -1607,7 +1607,7 @@ ParserDriver::ParserDriver(std::istream& input, ParserMode parserMode,  ImportFe
 	initialize();
 	_tokenStreams.emplace(std::make_shared<TokenStream>());
 	_locations.emplace();
-	_file = YaraFile(currentTokenStream());
+	_file = YaraFile(currentTokenStream(), _import_features);
 }
 
 /**
@@ -1674,7 +1674,7 @@ void ParserDriver::reset(ParserMode parserMode)
 	_optionalFirstInput = nullptr;
 	_valid = true;
 	_filePath.clear();
-	_file = YaraFile(currentTokenStream());
+	_file = YaraFile(currentTokenStream(), _import_features);
 	_currentStrings = std::weak_ptr<Rule::StringsTrie>();
 	_stringLoop = false;
 	_localSymbols.clear();
@@ -1882,7 +1882,7 @@ std::shared_ptr<Symbol> ParserDriver::findSymbol(const std::string& name) const
 	if (itr != _localSymbols.end())
 		return itr->second;
 
-	return _file.findSymbol(name, _import_features);
+	return _file.findSymbol(name);
 }
 
 /**

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -63,8 +63,10 @@ void addEnums(py::module& module)
 		.value("Regular", ParserMode::Regular)
 		.value("IncludeGuarded", ParserMode::IncludeGuarded);
 
-	py::enum_<ImportFeatures>(module, "ImportFeatures")
+	py::enum_<ImportFeatures>(module, "ImportFeatures", py::arithmetic())
 		.value("Basic", ImportFeatures::Basic)
+		.value("AvastOnly", ImportFeatures::AvastOnly)
+		.value("VirusTotalOnly", ImportFeatures::VirusTotalOnly)
 		.value("Avast", ImportFeatures::Avast)
 		.value("VirusTotal", ImportFeatures::VirusTotal)
 		.value("All", ImportFeatures::All);

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -63,6 +63,12 @@ void addEnums(py::module& module)
 		.value("Regular", ParserMode::Regular)
 		.value("IncludeGuarded", ParserMode::IncludeGuarded);
 
+	py::enum_<ImportFeatures>(module, "ImportFeatures")
+		.value("Basic", ImportFeatures::Basic)
+		.value("Avast", ImportFeatures::Avast)
+		.value("VirusTotal", ImportFeatures::VirusTotal)
+		.value("All", ImportFeatures::All);
+
 	py::enum_<IntMultiplier>(module, "IntMultiplier")
 		.value("Empty", IntMultiplier::None)
 		.value("Kilobytes", IntMultiplier::Kilobytes)
@@ -447,7 +453,7 @@ void addExpressionClasses(py::module& module)
 void addBuilderClasses(py::module& module)
 {
 	py::class_<YaraFileBuilder>(module, "YaraFileBuilder")
-		.def(py::init<>())
+		.def(py::init<ImportFeatures>(), py::arg("import_features") = ImportFeatures::All)
 		.def("get", [](YaraFileBuilder& self, bool recheck) {
 				return self.get(recheck, nullptr);
 			}, py::arg("recheck") = false)
@@ -611,7 +617,7 @@ void addBuilderClasses(py::module& module)
 void addMainClass(py::module& module)
 {
 	py::class_<Yaramod>(module, "Yaramod")
-		.def(py::init<>())
+		.def(py::init<ImportFeatures>(), py::arg("import_features") = ImportFeatures::All)
 		.def("parse_file", &Yaramod::parseFile, py::arg("file_path"), py::arg("parser_mode") = ParserMode::Regular)
 		.def("parse_string", [](Yaramod& self, const std::string& str, ParserMode parserMode) {
 				std::istringstream stream(str);

--- a/src/types/yara_file.cpp
+++ b/src/types/yara_file.cpp
@@ -12,114 +12,25 @@
 namespace yaramod {
 
 /**
- * Global variables of YARA file. These would be normally defined through -d option
- * of yara tool when it is being run. We don't have such option so we define them statically
- * for the all YARA files.
- */
-const std::vector<std::shared_ptr<Symbol>> YaraFile::globalVariables =
-{
-	// VirusTotal specific global variables
-	std::make_shared<ValueSymbol>("new_file", Expression::Type::Bool),
-	std::make_shared<ValueSymbol>("positives", Expression::Type::Int),
-	std::make_shared<ValueSymbol>("signatures", Expression::Type::String),
-	std::make_shared<ValueSymbol>("tags", Expression::Type::String),
-	std::make_shared<ValueSymbol>("md5", Expression::Type::String),
-	std::make_shared<ValueSymbol>("sha256", Expression::Type::String),
-	std::make_shared<ValueSymbol>("imphash", Expression::Type::String),
-	std::make_shared<ValueSymbol>("file_type", Expression::Type::String),
-	std::make_shared<ValueSymbol>("file_name", Expression::Type::String),
-	// VirusTotal specific global variables of antiviruses
-	std::make_shared<ValueSymbol>("a_squared", Expression::Type::String),
-	std::make_shared<ValueSymbol>("ad_aware", Expression::Type::String),
-	std::make_shared<ValueSymbol>("aegislab", Expression::Type::String),
-	std::make_shared<ValueSymbol>("agnitum", Expression::Type::String),
-	std::make_shared<ValueSymbol>("ahnlab", Expression::Type::String),
-	std::make_shared<ValueSymbol>("ahnlab_v3", Expression::Type::String),
-	std::make_shared<ValueSymbol>("alibaba", Expression::Type::String),
-	std::make_shared<ValueSymbol>("alyac", Expression::Type::String),
-	std::make_shared<ValueSymbol>("antivir", Expression::Type::String),
-	std::make_shared<ValueSymbol>("antivir7", Expression::Type::String),
-	std::make_shared<ValueSymbol>("antiy_avl", Expression::Type::String),
-	std::make_shared<ValueSymbol>("arcabit", Expression::Type::String),
-	std::make_shared<ValueSymbol>("authentium", Expression::Type::String),
-	std::make_shared<ValueSymbol>("avast", Expression::Type::String),
-	std::make_shared<ValueSymbol>("avg", Expression::Type::String),
-	std::make_shared<ValueSymbol>("avira", Expression::Type::String),
-	std::make_shared<ValueSymbol>("avware", Expression::Type::String),
-	std::make_shared<ValueSymbol>("baidu", Expression::Type::String),
-	std::make_shared<ValueSymbol>("bitdefender", Expression::Type::String),
-	std::make_shared<ValueSymbol>("bkav", Expression::Type::String),
-	std::make_shared<ValueSymbol>("bytehero", Expression::Type::String),
-	std::make_shared<ValueSymbol>("cat_quickheal", Expression::Type::String),
-	std::make_shared<ValueSymbol>("clamav", Expression::Type::String),
-	std::make_shared<ValueSymbol>("cmc", Expression::Type::String),
-	std::make_shared<ValueSymbol>("commtouch", Expression::Type::String),
-	std::make_shared<ValueSymbol>("comodo", Expression::Type::String),
-	std::make_shared<ValueSymbol>("crowdstrike", Expression::Type::String),
-	std::make_shared<ValueSymbol>("cyren", Expression::Type::String),
-	std::make_shared<ValueSymbol>("drweb", Expression::Type::String),
-	std::make_shared<ValueSymbol>("emsisoft", Expression::Type::String),
-	std::make_shared<ValueSymbol>("esafe", Expression::Type::String),
-	std::make_shared<ValueSymbol>("escan", Expression::Type::String),
-	std::make_shared<ValueSymbol>("eset_nod32", Expression::Type::String),
-	std::make_shared<ValueSymbol>("f_prot", Expression::Type::String),
-	std::make_shared<ValueSymbol>("f_secure", Expression::Type::String),
-	std::make_shared<ValueSymbol>("fortinet", Expression::Type::String),
-	std::make_shared<ValueSymbol>("gdata", Expression::Type::String),
-	std::make_shared<ValueSymbol>("ikarus", Expression::Type::String),
-	std::make_shared<ValueSymbol>("invincea", Expression::Type::String),
-	std::make_shared<ValueSymbol>("jiangmin", Expression::Type::String),
-	std::make_shared<ValueSymbol>("k7antivirus", Expression::Type::String),
-	std::make_shared<ValueSymbol>("k7gw", Expression::Type::String),
-	std::make_shared<ValueSymbol>("kaspersky", Expression::Type::String),
-	std::make_shared<ValueSymbol>("kingsoft", Expression::Type::String),
-	std::make_shared<ValueSymbol>("malwarebytes", Expression::Type::String),
-	std::make_shared<ValueSymbol>("mcafee", Expression::Type::String),
-	std::make_shared<ValueSymbol>("mcafee_gw_edition", Expression::Type::String),
-	std::make_shared<ValueSymbol>("microsoft", Expression::Type::String),
-	std::make_shared<ValueSymbol>("microworld_escan", Expression::Type::String),
-	std::make_shared<ValueSymbol>("nano_antivirus", Expression::Type::String),
-	std::make_shared<ValueSymbol>("nod32", Expression::Type::String),
-	std::make_shared<ValueSymbol>("norman", Expression::Type::String),
-	std::make_shared<ValueSymbol>("nprotect", Expression::Type::String),
-	std::make_shared<ValueSymbol>("panda", Expression::Type::String),
-	std::make_shared<ValueSymbol>("pctools", Expression::Type::String),
-	std::make_shared<ValueSymbol>("prevx", Expression::Type::String),
-	std::make_shared<ValueSymbol>("prevx1", Expression::Type::String),
-	std::make_shared<ValueSymbol>("qihoo_360", Expression::Type::String),
-	std::make_shared<ValueSymbol>("rising", Expression::Type::String),
-	std::make_shared<ValueSymbol>("sophos", Expression::Type::String),
-	std::make_shared<ValueSymbol>("sunbelt", Expression::Type::String),
-	std::make_shared<ValueSymbol>("superantispyware", Expression::Type::String),
-	std::make_shared<ValueSymbol>("symantec", Expression::Type::String),
-	std::make_shared<ValueSymbol>("tencent", Expression::Type::String),
-	std::make_shared<ValueSymbol>("thehacker", Expression::Type::String),
-	std::make_shared<ValueSymbol>("totaldefense", Expression::Type::String),
-	std::make_shared<ValueSymbol>("trendmicro", Expression::Type::String),
-	std::make_shared<ValueSymbol>("trendmicro_housecall", Expression::Type::String),
-	std::make_shared<ValueSymbol>("vba32", Expression::Type::String),
-	std::make_shared<ValueSymbol>("vipre", Expression::Type::String),
-	std::make_shared<ValueSymbol>("virobot", Expression::Type::String),
-	std::make_shared<ValueSymbol>("yandex", Expression::Type::String),
-	std::make_shared<ValueSymbol>("zillya", Expression::Type::String),
-	std::make_shared<ValueSymbol>("zoner", Expression::Type::String)
-};
-
-/**
  * Constructor.
  */
-YaraFile::YaraFile()
-	: YaraFile(std::make_shared<TokenStream>())
+YaraFile::YaraFile(ImportFeatures features)
+	: YaraFile(std::make_shared<TokenStream>(), features)
 {
+	if (_importFeatures & ImportFeatures::VirusTotalOnly)
+		initializeVTSymbols();
 }
 
-YaraFile::YaraFile(const std::shared_ptr<TokenStream>& tokenStream)
+YaraFile::YaraFile(const std::shared_ptr<TokenStream>& tokenStream, ImportFeatures features)
 	: _tokenStream(std::move(tokenStream))
 	, _imports()
 	, _rules()
 	, _importTable()
 	, _ruleTable()
+	, _importFeatures(features)
 {
+	if (_importFeatures & ImportFeatures::VirusTotalOnly)
+		initializeVTSymbols();
 }
 
 YaraFile::YaraFile(YaraFile&& o) noexcept
@@ -128,6 +39,8 @@ YaraFile::YaraFile(YaraFile&& o) noexcept
 	, _rules(std::move(o._rules))
 	, _importTable(std::move(o._importTable))
 	, _ruleTable(std::move(o._ruleTable))
+	, _importFeatures(std::move(o._importFeatures))
+	, _vtSymbols(std::move(o._vtSymbols))
 {
 }
 
@@ -138,7 +51,103 @@ YaraFile& YaraFile::operator=(YaraFile&& o) noexcept
 	std::swap(_rules, o._rules);
 	std::swap(_importTable, o._importTable);
 	std::swap(_ruleTable, o._ruleTable);
+	std::swap(_importFeatures, o._importFeatures);
+	std::swap(_vtSymbols, o._vtSymbols);
 	return *this;
+}
+
+/**
+ * VirusTotal symbols
+ */
+void YaraFile::initializeVTSymbols()
+{
+	_vtSymbols = {
+		// VirusTotal specific global variables
+		std::make_shared<ValueSymbol>("new_file", Expression::Type::Bool),
+		std::make_shared<ValueSymbol>("positives", Expression::Type::Int),
+		std::make_shared<ValueSymbol>("signatures", Expression::Type::String),
+		std::make_shared<ValueSymbol>("tags", Expression::Type::String),
+		std::make_shared<ValueSymbol>("md5", Expression::Type::String),
+		std::make_shared<ValueSymbol>("sha256", Expression::Type::String),
+		std::make_shared<ValueSymbol>("imphash", Expression::Type::String),
+		std::make_shared<ValueSymbol>("file_type", Expression::Type::String),
+		std::make_shared<ValueSymbol>("file_name", Expression::Type::String),
+		// VirusTotal specific global variables of antiviruses
+		std::make_shared<ValueSymbol>("a_squared", Expression::Type::String),
+		std::make_shared<ValueSymbol>("ad_aware", Expression::Type::String),
+		std::make_shared<ValueSymbol>("aegislab", Expression::Type::String),
+		std::make_shared<ValueSymbol>("agnitum", Expression::Type::String),
+		std::make_shared<ValueSymbol>("ahnlab", Expression::Type::String),
+		std::make_shared<ValueSymbol>("ahnlab_v3", Expression::Type::String),
+		std::make_shared<ValueSymbol>("alibaba", Expression::Type::String),
+		std::make_shared<ValueSymbol>("alyac", Expression::Type::String),
+		std::make_shared<ValueSymbol>("antivir", Expression::Type::String),
+		std::make_shared<ValueSymbol>("antivir7", Expression::Type::String),
+		std::make_shared<ValueSymbol>("antiy_avl", Expression::Type::String),
+		std::make_shared<ValueSymbol>("arcabit", Expression::Type::String),
+		std::make_shared<ValueSymbol>("authentium", Expression::Type::String),
+		std::make_shared<ValueSymbol>("avast", Expression::Type::String),
+		std::make_shared<ValueSymbol>("avg", Expression::Type::String),
+		std::make_shared<ValueSymbol>("avira", Expression::Type::String),
+		std::make_shared<ValueSymbol>("avware", Expression::Type::String),
+		std::make_shared<ValueSymbol>("baidu", Expression::Type::String),
+		std::make_shared<ValueSymbol>("bitdefender", Expression::Type::String),
+		std::make_shared<ValueSymbol>("bkav", Expression::Type::String),
+		std::make_shared<ValueSymbol>("bytehero", Expression::Type::String),
+		std::make_shared<ValueSymbol>("cat_quickheal", Expression::Type::String),
+		std::make_shared<ValueSymbol>("clamav", Expression::Type::String),
+		std::make_shared<ValueSymbol>("cmc", Expression::Type::String),
+		std::make_shared<ValueSymbol>("commtouch", Expression::Type::String),
+		std::make_shared<ValueSymbol>("comodo", Expression::Type::String),
+		std::make_shared<ValueSymbol>("crowdstrike", Expression::Type::String),
+		std::make_shared<ValueSymbol>("cyren", Expression::Type::String),
+		std::make_shared<ValueSymbol>("drweb", Expression::Type::String),
+		std::make_shared<ValueSymbol>("emsisoft", Expression::Type::String),
+		std::make_shared<ValueSymbol>("esafe", Expression::Type::String),
+		std::make_shared<ValueSymbol>("escan", Expression::Type::String),
+		std::make_shared<ValueSymbol>("eset_nod32", Expression::Type::String),
+		std::make_shared<ValueSymbol>("f_prot", Expression::Type::String),
+		std::make_shared<ValueSymbol>("f_secure", Expression::Type::String),
+		std::make_shared<ValueSymbol>("fortinet", Expression::Type::String),
+		std::make_shared<ValueSymbol>("gdata", Expression::Type::String),
+		std::make_shared<ValueSymbol>("ikarus", Expression::Type::String),
+		std::make_shared<ValueSymbol>("invincea", Expression::Type::String),
+		std::make_shared<ValueSymbol>("jiangmin", Expression::Type::String),
+		std::make_shared<ValueSymbol>("k7antivirus", Expression::Type::String),
+		std::make_shared<ValueSymbol>("k7gw", Expression::Type::String),
+		std::make_shared<ValueSymbol>("kaspersky", Expression::Type::String),
+		std::make_shared<ValueSymbol>("kingsoft", Expression::Type::String),
+		std::make_shared<ValueSymbol>("malwarebytes", Expression::Type::String),
+		std::make_shared<ValueSymbol>("mcafee", Expression::Type::String),
+		std::make_shared<ValueSymbol>("mcafee_gw_edition", Expression::Type::String),
+		std::make_shared<ValueSymbol>("microsoft", Expression::Type::String),
+		std::make_shared<ValueSymbol>("microworld_escan", Expression::Type::String),
+		std::make_shared<ValueSymbol>("nano_antivirus", Expression::Type::String),
+		std::make_shared<ValueSymbol>("nod32", Expression::Type::String),
+		std::make_shared<ValueSymbol>("norman", Expression::Type::String),
+		std::make_shared<ValueSymbol>("nprotect", Expression::Type::String),
+		std::make_shared<ValueSymbol>("panda", Expression::Type::String),
+		std::make_shared<ValueSymbol>("pctools", Expression::Type::String),
+		std::make_shared<ValueSymbol>("prevx", Expression::Type::String),
+		std::make_shared<ValueSymbol>("prevx1", Expression::Type::String),
+		std::make_shared<ValueSymbol>("qihoo_360", Expression::Type::String),
+		std::make_shared<ValueSymbol>("rising", Expression::Type::String),
+		std::make_shared<ValueSymbol>("sophos", Expression::Type::String),
+		std::make_shared<ValueSymbol>("sunbelt", Expression::Type::String),
+		std::make_shared<ValueSymbol>("superantispyware", Expression::Type::String),
+		std::make_shared<ValueSymbol>("symantec", Expression::Type::String),
+		std::make_shared<ValueSymbol>("tencent", Expression::Type::String),
+		std::make_shared<ValueSymbol>("thehacker", Expression::Type::String),
+		std::make_shared<ValueSymbol>("totaldefense", Expression::Type::String),
+		std::make_shared<ValueSymbol>("trendmicro", Expression::Type::String),
+		std::make_shared<ValueSymbol>("trendmicro_housecall", Expression::Type::String),
+		std::make_shared<ValueSymbol>("vba32", Expression::Type::String),
+		std::make_shared<ValueSymbol>("vipre", Expression::Type::String),
+		std::make_shared<ValueSymbol>("virobot", Expression::Type::String),
+		std::make_shared<ValueSymbol>("yandex", Expression::Type::String),
+		std::make_shared<ValueSymbol>("zillya", Expression::Type::String),
+		std::make_shared<ValueSymbol>("zoner", Expression::Type::String)
+	};
 }
 
 /**
@@ -182,9 +191,9 @@ std::string YaraFile::getTextFormatted(bool withIncludes) const
  *
  * @return @c true if module was found, @c false otherwise.
  */
-bool YaraFile::addImport(TokenIt import, ImportFeatures features, ModulesPool& modules)
+bool YaraFile::addImport(TokenIt import, ModulesPool& modules)
 {
-	auto module = modules.load(import->getPureText(), features);
+	auto module = modules.load(import->getPureText(), _importFeatures);
 	if (!module)
 		return false;
 
@@ -248,11 +257,11 @@ void YaraFile::addRules(const std::vector<std::shared_ptr<Rule>>& rules)
  *
  * @return @c true if modules were found, @c false otherwise.
  */
-bool YaraFile::addImports(const std::vector<TokenIt>& imports, ImportFeatures features, ModulesPool& modules)
+bool YaraFile::addImports(const std::vector<TokenIt>& imports, ModulesPool& modules)
 {
 	for (const TokenIt& module : imports)
 	{
-		if (!addImport(module, features, modules))
+		if (!addImport(module, modules))
 			return false;
 	}
 
@@ -322,7 +331,7 @@ const std::vector<std::shared_ptr<Rule>>& YaraFile::getRules() const
  *
  * @return Returns valid symbol if it was found, @c nullptr otherwise.
  */
-std::shared_ptr<Symbol> YaraFile::findSymbol(const std::string& name, ImportFeatures features) const
+std::shared_ptr<Symbol> YaraFile::findSymbol(const std::string& name) const
 {
 	// @todo Should rules have priority over imported modules?
 	if (auto itr = _ruleTable.find(name); itr != _ruleTable.end())
@@ -331,13 +340,10 @@ std::shared_ptr<Symbol> YaraFile::findSymbol(const std::string& name, ImportFeat
 	if (auto itr = _importTable.find(name); itr != _importTable.end())
 		return itr->second->getStructure();
 
-	if (features & ImportFeatures::VirusTotalOnly)
+	for (const auto& vtSymbol : _vtSymbols)
 	{
-		for (const auto& globalVar : YaraFile::globalVariables)
-		{
-			if (globalVar->getName() == name)
-				return globalVar;
-		}
+		if (vtSymbol->getName() == name)
+			return vtSymbol;
 	}
 
 	return nullptr;

--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -4,7 +4,7 @@ import yaramod
 
 class BuilderTests(unittest.TestCase):
     def setUp(self):
-        self.new_file = yaramod.YaraFileBuilder()
+        self.new_file = yaramod.YaraFileBuilder(yaramod.ImportFeatures.All)
         self.new_rule = yaramod.YaraRuleBuilder()
 
     def test_empty_file(self):
@@ -14,14 +14,17 @@ class BuilderTests(unittest.TestCase):
 
     def test_pure_imports(self):
         yara_file = self.new_file \
+            .with_module('phish') \
             .with_module('pe') \
             .with_module('elf') \
             .get()
 
-        self.assertEqual(yara_file.text_formatted, '''import "pe"
+        self.assertEqual(yara_file.text_formatted, '''import "phish"
+import "pe"
 import "elf"
 ''')
-        self.assertEqual(yara_file.text, '''import "pe"
+        self.assertEqual(yara_file.text, '''import "phish"
+import "pe"
 import "elf"
 ''')
 

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -251,17 +251,43 @@ private rule private_rule {
     def test_import(self):
         yara_file = yaramod.Yaramod().parse_string('''
 import "pe"
+import "phish"
 
 rule dummy_rule {
     condition:
-        true
+        true and new_file
 }''')
 
-        self.assertEqual(len(yara_file.imports), 1)
+        self.assertEqual(len(yara_file.imports), 2)
         self.assertEqual(len(yara_file.rules), 1)
 
         module = yara_file.imports[0]
         self.assertEqual(module.name, 'pe')
+
+    def test_imports_without_avast_symbols(self):
+        input_text = '''
+import "pe"
+import "phish"
+
+rule dummy_rule {
+    condition:
+        true
+}'''
+        ymod = yaramod.Yaramod(yaramod.ImportFeatures.VirusTotal)
+        with self.assertRaises(yaramod.ParserError):
+            ymod.parse_string(input_text)
+
+    def test_imports_without_virus_total_symbols(self):
+        input_text = '''
+import "pe"
+
+rule dummy_rule {
+    condition:
+        true and new_file
+}'''
+        ymod = yaramod.Yaramod(yaramod.ImportFeatures.Avast)
+        with self.assertRaises(yaramod.ParserError):
+            ymod.parse_string(input_text)
 
     def test_bool_literal_condition(self):
         yara_file = yaramod.Yaramod().parse_string('''


### PR DESCRIPTION
This PR makes the TirusTotal-specific symbols non-global and assign them to each `YaraFile` instance. Also, yaramod python bindings are enhanced of `ImportFeatures` enabling the user to choose if they need Avast-specific or VirusTotal-specific symbols. This is all tested in python parser tests.