### PR TITLE
Fixed builder conjunction/disjunction with single term

### DIFF
--- a/src/builder/yara_expression_builder.cpp
+++ b/src/builder/yara_expression_builder.cpp
@@ -37,7 +37,7 @@ YaraExpressionBuilder logicalFormula(std::vector<YaraExpressionBuilder> terms, c
 		return boolVal(true);
 
 	if (terms.size() == 1)
-		return { terms.front().get() };
+		return terms.front();
 
 	auto formula = op(terms[0], terms[1]);
 	for (std::size_t i = 2; i < terms.size(); ++i)

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -1580,5 +1580,34 @@ RuleWithXorStringModifierLowerBoundGreaterThanHigherBound) {
 	}
 }
 
+TEST_F(BuilderTests,
+ConjunctionWithSingleTerm) {
+	auto cond = conjunction({boolVal(false)}).get();
+
+	YaraRuleBuilder newRule;
+	auto rule = newRule
+		.withName("conjunction_with_single_term")
+		.withCondition(cond)
+		.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+		.withRule(std::move(rule))
+		.get(true);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(rule conjunction_with_single_term {
+	condition:
+		false
+})", yaraFile->getText());
+
+	EXPECT_EQ(R"(rule conjunction_with_single_term
+{
+	condition:
+		false
+}
+)", yaraFile->getTextFormatted());
+}
+
 }
 }


### PR DESCRIPTION
Single term calls to conjunction()/disjunction() resulted in wrong
condition being produced. The reason is that token stream of the
underlying expression was not copied when it was constructed.