### PR TITLE
YaraRuleBuilder allows empty string meta values (issue #58)

### DIFF
--- a/src/builder/yara_rule_builder.cpp
+++ b/src/builder/yara_rule_builder.cpp
@@ -176,8 +176,8 @@ YaraRuleBuilder& YaraRuleBuilder::withComment(const std::string& comment, bool m
  */
 YaraRuleBuilder& YaraRuleBuilder::withStringMeta(const std::string& key, const std::string& value)
 {
-	if (key == std::string{} || value == std::string{})
-		throw RuleBuilderError("Error: String-Meta key and value must be non-empty.");
+	if (key == std::string{})
+		throw RuleBuilderError("Error: String-Meta key must be non-empty.");
 
 	TokenIt insert_before = _strings_it.value_or(_condition_it);
 

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -142,7 +142,7 @@ RuleWithMetasWorks) {
 }
 
 TEST_F(BuilderTests,
-RuleWithEmptyStringMetasWorks) {
+RuleWithEmptyStringMetaValueWorks) {
 	YaraRuleBuilder newRule;
 	auto rule = newRule
 		.withName("rule_with_metas")

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -142,6 +142,37 @@ RuleWithMetasWorks) {
 }
 
 TEST_F(BuilderTests,
+RuleWithEmptyStringMetasWorks) {
+	YaraRuleBuilder newRule;
+	auto rule = newRule
+		.withName("rule_with_metas")
+		.withStringMeta("string_meta", "")
+		.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+		.withRule(std::move(rule))
+		.get(true);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(rule rule_with_metas {
+	meta:
+		string_meta = ""
+	condition:
+		true
+})", yaraFile->getText());
+
+	EXPECT_EQ(R"(rule rule_with_metas
+{
+	meta:
+		string_meta = ""
+	condition:
+		true
+}
+)", yaraFile->getTextFormatted());
+}
+
+TEST_F(BuilderTests,
 RuleWithTagsWorks) {
 	YaraRuleBuilder newRule;
 	auto rule = newRule


### PR DESCRIPTION
YaraRuleBuilder allows now to create string meta with empty string as value.