### PR TITLE
Deprecated import feature (issue #62)

### DIFF
--- a/include/yaramod/builder/yara_file_builder.h
+++ b/include/yaramod/builder/yara_file_builder.h
@@ -36,7 +36,7 @@ class YaraFileBuilder
 public:
 	/// @name Constructors
 	/// @{
-	YaraFileBuilder(ImportFeatures features = ImportFeatures::All)
+	YaraFileBuilder(ImportFeatures features = ImportFeatures::AllCurrent)
 		: _tokenStream(std::make_shared<TokenStream>())
 		, _import_features(features)
 	{

--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -77,7 +77,7 @@ class ParserDriver
 public:
 	/// @name Constructors
 	/// @{
-	ParserDriver(ImportFeatures features = ImportFeatures::All);
+	ParserDriver(ImportFeatures features = ImportFeatures::AllCurrent);
 	/// @}
 
 	/// @name Destructor

--- a/include/yaramod/types/modules/module.h
+++ b/include/yaramod/types/modules/module.h
@@ -19,12 +19,14 @@ namespace yaramod {
  */
 enum ImportFeatures
 {
-	Basic = 0x01,          // 001 - such module is always loaded
-	AvastOnly = 0x02,      // 010 - such module is loaded when Avast specified
-	VirusTotalOnly = 0x04, // 100 - such module is loaded when VirusTotal specified
-	Avast = Basic | AvastOnly,           // 011 - specification which will load all basic and Avast-specific modules
-	VirusTotal = Basic | VirusTotalOnly, // 101 - specification which will load all basic and VirusTotal-specific modules
-	All = Avast | VirusTotal             // 111 - specification which will load all modules
+	Basic = 0x01,          // 0001 - such module is always loaded
+	AvastOnly = 0x02,      // 0010 - such module is loaded when Avast specified
+	VirusTotalOnly = 0x04, // 0100 - such module is loaded when VirusTotal specified
+	Deprecated = 0x08,     // 1000 - such module is deprecated
+	Avast = Basic | AvastOnly,           // 0011 - specification which will load all basic and Avast-specific modules
+	VirusTotal = Basic | VirusTotalOnly, // 0101 - specification which will load all basic and VirusTotal-specific modules
+	AllCurrent = Avast | VirusTotal,     // 0111 - specification which will load all currently used modules
+	Everything = AllCurrent | Deprecated // 1111 - specification which will load everything - even old deprecated modules
 };
 
 /**

--- a/include/yaramod/types/yara_file.h
+++ b/include/yaramod/types/yara_file.h
@@ -22,8 +22,8 @@ class YaraFile
 public:
 	/// @name Constructors
 	/// @{
-	YaraFile(ImportFeatures features = ImportFeatures::All);
-	YaraFile(const std::shared_ptr<TokenStream>& tokenStream, ImportFeatures features = ImportFeatures::All);
+	YaraFile(ImportFeatures features = ImportFeatures::AllCurrent);
+	YaraFile(const std::shared_ptr<TokenStream>& tokenStream, ImportFeatures features = ImportFeatures::AllCurrent);
 	YaraFile(YaraFile&&) noexcept;
 
 	YaraFile& operator=(YaraFile&&) noexcept;

--- a/include/yaramod/yaramod.h
+++ b/include/yaramod/yaramod.h
@@ -36,7 +36,7 @@ public:
 	 *
 	 * @param features determines iff we want to use aditional Avast-specific symbols or VirusTotal-specific symbols in the imported modules
 	 */
-	Yaramod(ImportFeatures features = ImportFeatures::All) : _driver(features) {}
+	Yaramod(ImportFeatures features = ImportFeatures::AllCurrent) : _driver(features) {}
 	/**
 	 * Parses file at given path.
 	 *

--- a/src/builder/yara_file_builder.cpp
+++ b/src/builder/yara_file_builder.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<YaraFile> YaraFileBuilder::get(bool recheck, ParserDriver* exter
 		}
 		else
 		{
-			ParserDriver driver(ImportFeatures::All);
+			ParserDriver driver(ImportFeatures::AllCurrent);
 			try
 			{
 				driver.parse(ss);

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -70,7 +70,8 @@ void addEnums(py::module& module)
 		.value("VirusTotalOnly", ImportFeatures::VirusTotalOnly)
 		.value("Avast", ImportFeatures::Avast)
 		.value("VirusTotal", ImportFeatures::VirusTotal)
-		.value("All", ImportFeatures::All);
+		.value("AllCurrent", ImportFeatures::AllCurrent)
+		.value("Everything", ImportFeatures::Everything);
 
 	py::enum_<IntMultiplier>(module, "IntMultiplier")
 		.value("Empty", IntMultiplier::None)
@@ -456,7 +457,7 @@ void addExpressionClasses(py::module& module)
 void addBuilderClasses(py::module& module)
 {
 	py::class_<YaraFileBuilder>(module, "YaraFileBuilder")
-		.def(py::init<ImportFeatures>(), py::arg("import_features") = ImportFeatures::All)
+		.def(py::init<ImportFeatures>(), py::arg("import_features") = ImportFeatures::AllCurrent)
 		.def("get", [](YaraFileBuilder& self, bool recheck) {
 				return self.get(recheck, nullptr);
 			}, py::arg("recheck") = false)
@@ -620,7 +621,7 @@ void addBuilderClasses(py::module& module)
 void addMainClass(py::module& module)
 {
 	py::class_<Yaramod>(module, "Yaramod")
-		.def(py::init<ImportFeatures>(), py::arg("import_features") = ImportFeatures::All)
+		.def(py::init<ImportFeatures>(), py::arg("import_features") = ImportFeatures::AllCurrent)
 		.def("parse_file", &Yaramod::parseFile, py::arg("file_path"), py::arg("parser_mode") = ParserMode::Regular)
 		.def("parse_string", [](Yaramod& self, const std::string& str, ParserMode parserMode) {
 				std::istringstream stream(str);

--- a/src/types/modules/cuckoo_module.cpp
+++ b/src/types/modules/cuckoo_module.cpp
@@ -81,30 +81,40 @@ bool CuckooModule::initialize(ImportFeatures features)
 		syncStruct->addAttribute(std::make_shared<FunctionSymbol>("timer", Type::Int, Type::Regexp));
 	}
 	cuckooStruct->addAttribute(syncStruct);
-	if (features & ImportFeatures::AvastOnly)
+	if (features & (ImportFeatures::AvastOnly | ImportFeatures::Deprecated))
 	{
-		auto processStruct = std::make_shared<StructureSymbol>("process");
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("executed_command", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("created_service", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("started_service", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("resolved_api", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("load_path", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("load_sha256", Type::Int, Type::String));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("api_call", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("modified_clipboard", Type::Int, Type::Regexp));
-		processStruct->addAttribute(std::make_shared<FunctionSymbol>("scheduled_task", Type::Int, Type::Regexp));
-		cuckooStruct->addAttribute(processStruct);
+		if (features & ImportFeatures::AvastOnly)
+		{
+			auto processStruct = std::make_shared<StructureSymbol>("process");
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("executed_command", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("created_service", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("started_service", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("resolved_api", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("load_path", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("load_sha256", Type::Int, Type::String));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("api_call", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("modified_clipboard", Type::Int, Type::Regexp));
+			processStruct->addAttribute(std::make_shared<FunctionSymbol>("scheduled_task", Type::Int, Type::Regexp));
+			cuckooStruct->addAttribute(processStruct);
 
+			auto summaryStruct = std::make_shared<StructureSymbol>("summary");
+			summaryStruct->addAttribute(std::make_shared<FunctionSymbol>("ml_score", Type::Float, Type::String));
+			cuckooStruct->addAttribute(summaryStruct);
+		}
 		auto signatureStruct = std::make_shared<StructureSymbol>("signature");
-		signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::Regexp));
-		signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::Regexp, Type::Regexp));
-		signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::String));
-		signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::String, Type::Regexp));
+		if (features & ImportFeatures::AvastOnly)
+		{
+			signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::Regexp));
+			signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::Regexp, Type::Regexp));
+			signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::String));
+			signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("hits", Type::Int, Type::String, Type::Regexp));
+		}
+		if (features & ImportFeatures::Deprecated)
+		{
+			assert(features & ImportFeatures::Deprecated);
+			signatureStruct->addAttribute(std::make_shared<FunctionSymbol>("name", Type::Int, Type::Regexp));
+		}
 		cuckooStruct->addAttribute(signatureStruct);
-
-		auto summaryStruct = std::make_shared<StructureSymbol>("summary");
-		summaryStruct->addAttribute(std::make_shared<FunctionSymbol>("ml_score", Type::Float, Type::String));
-		cuckooStruct->addAttribute(summaryStruct);
 	}
 	_structure = cuckooStruct;
 	return true;

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -2633,6 +2633,33 @@ rule cuckoo_module
 }
 
 TEST_F(ParserTests,
+CuckooModuleDeprecated) {
+	prepareInput(
+R"(
+import "cuckoo"
+
+rule cuckoo_module_deprecated
+{
+	condition:
+		cuckoo.network.http_request(/regexp/) and
+		cuckoo.network.http_request_body(/regexp/) and
+		cuckoo.signature.name(/regexp/)
+}
+)");
+
+	ParserDriver driverDeprecatedSymbols(ImportFeatures::Everything);
+	std::stringstream input2(input_text);
+
+	EXPECT_TRUE(driverDeprecatedSymbols.parse(input));
+	ASSERT_EQ(1u, driverDeprecatedSymbols.getParsedFile().getRules().size());
+
+	const auto& rule = driverDeprecatedSymbols.getParsedFile().getRules()[0];
+	EXPECT_EQ(R"(cuckoo.network.http_request(/regexp/) and cuckoo.network.http_request_body(/regexp/) and cuckoo.signature.name(/regexp/))", rule->getCondition()->getText());
+
+	EXPECT_EQ(input_text, driverDeprecatedSymbols.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 DotnetModuleWorks) {
 	prepareInput(
 R"(

--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -4,7 +4,7 @@ import yaramod
 
 class BuilderTests(unittest.TestCase):
     def setUp(self):
-        self.new_file = yaramod.YaraFileBuilder(yaramod.ImportFeatures.All)
+        self.new_file = yaramod.YaraFileBuilder(yaramod.ImportFeatures.AllCurrent)
         self.new_rule = yaramod.YaraRuleBuilder()
 
     def test_empty_file(self):

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -289,6 +289,23 @@ rule dummy_rule {
         with self.assertRaises(yaramod.ParserError):
             ymod.parse_string(input_text)
 
+    def test_imports_with_deprecated_symbols(self):
+        yara_file = yaramod.Yaramod(yaramod.ImportFeatures.Everything).parse_string('''
+import "cuckoo"
+
+rule dummy_rule {
+    condition:
+        cuckoo.signature.hits(/regexp1/) and cuckoo.signature.name(/regexp2/) and new_file
+}''')
+
+        self.assertEqual(len(yara_file.imports), 1)
+        self.assertEqual(len(yara_file.rules), 1)
+
+        module = yara_file.imports[0]
+        self.assertEqual(module.name, 'cuckoo')
+        rule = yara_file.rules[0]
+        self.assertEqual(rule.condition.text, 'cuckoo.signature.hits(/regexp1/) and cuckoo.signature.name(/regexp2/) and new_file')
+
     def test_bool_literal_condition(self):
         yara_file = yaramod.Yaramod().parse_string('''
 rule bool_literal_condition {


### PR DESCRIPTION
This PR enables yaramod to parse files containing deprecated symbols / modules. We rename the default `ImportFeatures::All` to `ImportFeatures::AllCurrent` and add new `ImportFeatures::Everything` also loading deprecated symbols / modules.

Users that need deprecated symbols can simply pass `ImportFeatures::Everything` to the `Yaramod` class constructor.