### PR TITLE
Remove blank lines

### DIFF
--- a/include/yaramod/types/token_stream.h
+++ b/include/yaramod/types/token_stream.h
@@ -136,7 +136,8 @@ public:
 protected:
 	void getTextProcedure(PrintHelper& helper, std::stringstream* os, bool withIncludes, bool alignComments);
 	void autoformat();
-	void determineNewlineSectors();
+	bool determineNewlineSectors();
+	void removeRedundantDoubleNewlines();
 	void addMissingNewLines();
 
 	std::optional<TokenIt> predecessor(TokenIt it);

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -306,6 +306,7 @@ bool TokenStream::determineNewlineSectors()
 		else
 			wasLine = false;
 	}
+	// when more than half of the newlines is "doubled", then all "doubled" newlines are made simple newline.
 	return 3 * doubleLineCounter > lineCounter;
 }
 

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -325,7 +325,7 @@ void TokenStream::removeRedundantDoubleNewlines()
 			break;
 		auto next = nextIt->getType();
 		if (inside_rule && current == NEW_LINE && next == NEW_LINE)
-			it = erase(nextIt);
+			erase(nextIt);
 		else
 			++it;
 	}

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -311,8 +311,8 @@ bool TokenStream::determineNewlineSectors()
 
 void TokenStream::removeRedundantDoubleNewlines()
 {
-	bool inside_rule;
-	for (auto it = begin(); it != end(); ++it)
+	bool inside_rule = false;
+	for (auto it = begin(); it != end();)
 	{
 		auto current = it->getType();
 		if(current == RULE_BEGIN)
@@ -324,7 +324,9 @@ void TokenStream::removeRedundantDoubleNewlines()
 			break;
 		auto next = nextIt->getType();
 		if (inside_rule && current == NEW_LINE && next == NEW_LINE)
-			erase(nextIt);
+			it = erase(nextIt);
+		else
+			++it;
 	}
 }
 

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -275,9 +275,12 @@ private:
 };
 
 
-void TokenStream::determineNewlineSectors()
+bool TokenStream::determineNewlineSectors()
 {
 	std::stack<TokenIt> leftBrackets;
+	std::size_t lineCounter = 0;
+	std::size_t doubleLineCounter = 0;
+	bool wasLine = false;
 	for (auto it = begin(); it != end(); ++it)
 	{
 		auto current = it->getType();
@@ -291,6 +294,37 @@ void TokenStream::determineNewlineSectors()
 		}
 		else if (!leftBrackets.empty() && (current == NEW_LINE || current == OR || current == AND))
 			leftBrackets.top()->setFlag(true);
+
+		// Here we count lines and double lines:
+		if (current == NEW_LINE)
+		{
+			++lineCounter;
+			if (wasLine)
+				++doubleLineCounter;
+			wasLine = true;
+		}
+		else
+			wasLine = false;
+	}
+	return 3 * doubleLineCounter > lineCounter;
+}
+
+void TokenStream::removeRedundantDoubleNewlines()
+{
+	bool inside_rule;
+	for (auto it = begin(); it != end(); ++it)
+	{
+		auto current = it->getType();
+		if(current == RULE_BEGIN)
+			inside_rule = true;
+		if(current == RULE_END)
+			inside_rule = false;
+		auto nextIt = std::next(it);
+		if (nextIt == end())
+			break;
+		auto next = nextIt->getType();
+		if (inside_rule && current == NEW_LINE && next == NEW_LINE)
+			erase(nextIt);
 	}
 }
 
@@ -375,7 +409,9 @@ void TokenStream::addMissingNewLines()
 
 void TokenStream::autoformat()
 {
-	determineNewlineSectors();
+	bool redundant = determineNewlineSectors();
+	if (redundant)
+		removeRedundantDoubleNewlines();
 	addMissingNewLines();
 	_formatted = true;
 }

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4929,11 +4929,21 @@ R"(rule rule_name {
 
 	meta:
 
+
 		key = "value"
+
+
 
 	condition:
 
+
+
+
 		true
+
+
+
+
 })");
 	EXPECT_TRUE(driver.parse(input));
 	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4952,7 +4952,10 @@ std::string expected = R"(rule rule_name
 TEST_F(ParserTests,
 AutoformattingRemoveRedundantBlankLines2) {
 	prepareInput(
-R"(rule rule_name_1 {
+R"(
+import "cuckoo"
+
+rule rule_name_1 {
 
 	meta:
 
@@ -4970,7 +4973,7 @@ R"(rule rule_name_1 {
 
 	condition:
 
-		all of them
+		all of them and cuckoo.process.executed_command(/abc+/)
 
 }
 
@@ -4998,7 +5001,10 @@ rule rule_name_2 {
 	EXPECT_TRUE(driver.parse(input));
 	ASSERT_EQ(2u, driver.getParsedFile().getRules().size());
 
-std::string expected = R"(rule rule_name_1
+std::string expected = R"(
+import "cuckoo"
+
+rule rule_name_1
 {
 	meta:
 		title = "some unique title"
@@ -5008,7 +5014,8 @@ std::string expected = R"(rule rule_name_1
 		$string2 = "Fernsehrturm" wide
 		$string3 = { AA ?? }
 	condition:
-		all of them
+		all of them and
+		cuckoo.process.executed_command(/abc+/)
 }
 
 rule rule_name_2

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4923,6 +4923,111 @@ rule cruel_rule_2
 }
 
 TEST_F(ParserTests,
+AutoformattingRemoveRedundantBlankLines) {
+	prepareInput(
+R"(rule rule_name {
+
+	meta:
+
+		key = "value"
+
+	condition:
+
+		true
+})");
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+std::string expected = R"(rule rule_name
+{
+	meta:
+		key = "value"
+	condition:
+		true
+}
+)";
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+AutoformattingRemoveRedundantBlankLines2) {
+	prepareInput(
+R"(rule rule_name_1 {
+
+	meta:
+
+		title = "some unique title"
+
+		author = "Mr Avastien"
+
+	strings:
+
+		$string1 = " Brandenburger Tor"
+
+		$string2 = "Fernsehrturm" wide
+
+		$string3 =   { AA ?? }
+
+	condition:
+
+		all of them
+
+}
+
+rule rule_name_2 {
+
+	meta:
+
+		title = "the very same title"
+
+		author = "Mr Avastien"
+
+	strings:
+
+		$string1 = " burger"
+
+		$string2 = "Fernsehr"
+
+		$string3 =   { BB ?? }
+
+	condition:
+
+		all of them
+
+})");
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(2u, driver.getParsedFile().getRules().size());
+
+std::string expected = R"(rule rule_name_1
+{
+	meta:
+		title = "some unique title"
+		author = "Mr Avastien"
+	strings:
+		$string1 = " Brandenburger Tor"
+		$string2 = "Fernsehrturm" wide
+		$string3 = { AA ?? }
+	condition:
+		all of them
+}
+
+rule rule_name_2
+{
+	meta:
+		title = "the very same title"
+		author = "Mr Avastien"
+	strings:
+		$string1 = " burger"
+		$string2 = "Fernsehr"
+		$string3 = { BB ?? }
+	condition:
+		all of them
+}
+)";
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 AutoformattingCommentInsideHexstringOnNewline) {
 	prepareInput(
 R"(rule cruel_rule


### PR DESCRIPTION
This feature removes double blank lines and use just one blank line instead when there is too many blank lines in the rule (Iff more than one third of the new-lines in the rule is followed by another new-line). The removing is only performed inside of rules.