### PR TITLE
Builder: avoid duplicity of imports, sort imports lexicographically

### DIFF
--- a/include/yaramod/builder/yara_file_builder.h
+++ b/include/yaramod/builder/yara_file_builder.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -56,10 +57,13 @@ public:
 	YaraFileBuilder& withRule(const std::shared_ptr<Rule>& rule);
 	/// @}
 
+protected:
+	void insertImportIntoTokenStream(TokenIt before, const std::string& moduleName);
+
 private:
-	bool _lastAddedWasImport = false; ///< Flag to determine newlines
 	std::shared_ptr<TokenStream> _tokenStream; ///< Tokens storage
-	std::vector<TokenIt> _module_tokens; ///< Modules
+	std::map<std::string, TokenIt> _module_tokens; ///< Modules
+	TokenIt _newline_after_imports; ///< Always stands behind newline after last import in the TokenStream
 	ImportFeatures _import_features; ///< Determines which modules should be possible to load
 	ModulesPool _modules_pool; ///< Storage of used modules
 	std::vector<std::shared_ptr<Rule>> _rules; ///< Rules

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -41,8 +41,36 @@ PureImportsWorks) {
 		.get(true, &driver);
 
 	ASSERT_NE(nullptr, yaraFile);
-	EXPECT_EQ(R"(import "pe"
+	EXPECT_EQ(R"(import "elf"
+import "pe"
+)", yaraFile->getText());
+}
+
+TEST_F(BuilderTests,
+PureImportsComplicateWorks) {
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+		.withModule("pe")
+		.withModule("cuckoo")
+		.withModule("elf")
+		.get(true, &driver);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(import "cuckoo"
 import "elf"
+import "pe"
+)", yaraFile->getText());
+
+	yaraFile = newFile
+		.withModule("cuckoo")
+		.withModule("pe")
+		.withModule("elf")
+		.get(true, &driver);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(import "cuckoo"
+import "elf"
+import "pe"
 )", yaraFile->getText());
 }
 
@@ -68,6 +96,78 @@ UnnamedRuleWorks) {
 })", yaraFile->getText());
 
 	EXPECT_EQ(R"(rule unknown
+{
+	condition:
+		true
+}
+)", yaraFile->getTextFormatted());
+}
+
+TEST_F(BuilderTests,
+UnnamedRuleWithImportsWorks) {
+	YaraRuleBuilder newRule;
+	auto rule = newRule.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+		.withRule(std::move(rule))
+		.withModule("cuckoo")
+		.withModule("pe")
+		.withModule("cuckoo")
+		.withModule("elf")
+		.get(true);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(import "cuckoo"
+import "elf"
+import "pe"
+
+rule unknown {
+	condition:
+		true
+})", yaraFile->getText());
+
+	EXPECT_EQ(R"(import "cuckoo"
+import "elf"
+import "pe"
+
+rule unknown
+{
+	condition:
+		true
+}
+)", yaraFile->getTextFormatted());
+}
+
+TEST_F(BuilderTests,
+UnnamedRuleWithImportsWorks2) {
+	YaraRuleBuilder newRule;
+	auto rule = newRule.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+		.withModule("cuckoo")
+		.withModule("pe")
+		.withRule(std::move(rule))
+		.withModule("cuckoo")
+		.withModule("elf")
+		.get(true);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(import "cuckoo"
+import "elf"
+import "pe"
+
+rule unknown {
+	condition:
+		true
+})", yaraFile->getText());
+
+	EXPECT_EQ(R"(import "cuckoo"
+import "elf"
+import "pe"
+
+rule unknown
 {
 	condition:
 		true

--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -19,13 +19,14 @@ class BuilderTests(unittest.TestCase):
             .with_module('elf') \
             .get()
 
-        self.assertEqual(yara_file.text_formatted, '''import "phish"
+        self.assertEqual(yara_file.text_formatted, '''import "elf"
 import "pe"
-import "elf"
+import "phish"
+
 ''')
-        self.assertEqual(yara_file.text, '''import "phish"
+        self.assertEqual(yara_file.text, '''import "elf"
 import "pe"
-import "elf"
+import "phish"
 ''')
 
     def test_empty_rule(self):


### PR DESCRIPTION
Imports builded by YaraFileBuilder will be sorted in lexicographical order and without duplicities.