### PR TITLE
Align comments

### DIFF
--- a/include/yaramod/builder/yara_expression_builder.h
+++ b/include/yaramod/builder/yara_expression_builder.h
@@ -166,7 +166,7 @@ public:
 	YaraExpressionBuilder& operator<<(const YaraExpressionBuilder& other);
 	YaraExpressionBuilder& operator>>(const YaraExpressionBuilder& other);
 
-	YaraExpressionBuilder& comment(const std::string& message, bool multiline = false, const std::string& indent = "");
+	YaraExpressionBuilder& comment(const std::string& message, bool multiline = false, const std::string& indent = {});
 	YaraExpressionBuilder& call(const std::vector<YaraExpressionBuilder>& args);
 	/**
 	 * Calls function from an expression

--- a/include/yaramod/builder/yara_expression_builder.h
+++ b/include/yaramod/builder/yara_expression_builder.h
@@ -166,7 +166,7 @@ public:
 	YaraExpressionBuilder& operator<<(const YaraExpressionBuilder& other);
 	YaraExpressionBuilder& operator>>(const YaraExpressionBuilder& other);
 
-	YaraExpressionBuilder& comment(const std::string& message, bool multiline = false, const std::string& indent = "\t\t");
+	YaraExpressionBuilder& comment(const std::string& message, bool multiline = false, const std::string& indent = "");
 	YaraExpressionBuilder& call(const std::vector<YaraExpressionBuilder>& args);
 	/**
 	 * Calls function from an expression

--- a/include/yaramod/types/token_stream.h
+++ b/include/yaramod/types/token_stream.h
@@ -31,7 +31,7 @@ public:
 		std::size_t insertIntoStream(std::stringstream* ss, char what);
 		std::size_t insertIntoStream(std::stringstream* ss, const std::string& what, std::size_t length = 0);
 		std::size_t insertIntoStream(std::stringstream* ss, TokenStream* ts, TokenIt what);
-		std::size_t printComment(std::stringstream* ss, TokenStream* ts, TokenIt it, bool alignComment);
+		std::size_t printComment(std::stringstream* ss, TokenStream* ts, TokenIt it, int currentLineTabs, bool alignComment, bool ignoreUserIndent);
 	private:
 		std::size_t lineCounter = 0;
 		std::size_t columnCounter = 0;

--- a/src/builder/yara_expression_builder.cpp
+++ b/src/builder/yara_expression_builder.cpp
@@ -453,7 +453,9 @@ YaraExpressionBuilder& YaraExpressionBuilder::call(const std::vector<YaraExpress
 /**
  * Puts comment in front of the expression.
  *
- * @param other The other expression.
+ * @param message The comment message.
+ * @param multiline If set, the commet will be multiline.
+ * @param indent Additional indent added to the indentation computed by the autoformatter.
  *
  * @return Builder.
  */

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -312,7 +312,8 @@ void TokenStream::addMissingNewLines()
 		if (current == LP || current == LP_ENUMERATION || current == HEX_JUMP_LEFT_BRACKET || current == REGEXP_START_SLASH || current == HEX_START_BRACKET || current == LP_WITH_SPACE_AFTER || current == LP_WITH_SPACES)
 		{
 			brackets.addLeftBracket(lineCounter, it->getFlag());
-			if (brackets.putNewlineInCurrentSector() && next != NEW_LINE && next != ONELINE_COMMENT && next != COMMENT)
+			// ONELINE_COMMENTs are left right behind the left bracket. COMMENTs are put on separate new line.
+			if (brackets.putNewlineInCurrentSector() && next != NEW_LINE && next != ONELINE_COMMENT)
 			{
 				nextIt = emplace(nextIt, NEW_LINE, _new_line_style);
 				next = nextIt->getType();
@@ -452,7 +453,7 @@ std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenS
 		else if (alignComment && columnCounter < indentation && (!prevIt || (*prevIt)->getType() != COLON))
 			*ss << std::string(indentation - columnCounter, ' ');
 		*ss << it->getPureText();
-	} /*  */
+	}
 	else if (it->getType() == ONELINE_COMMENT && (!prevIt || (*prevIt)->getType() != COLON))
 	{
 		commentOnThisLine = true;

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -434,6 +434,18 @@ std::size_t TokenStream::PrintHelper::insertIntoStream(std::stringstream* ss, To
 	return columnCounter;
 }
 
+/**
+ * Prints comment.
+ *
+ * @param ts The associated tokenstream used only for predecessor access.
+ * @param ss The stream to be filled with the text.
+ * @param it The comment.
+ * @param currentLineTabs The current level of indentation based obtained from the autoformatter.
+ * @param alignComments Set if comments should be aligned.
+ * @patam ignoreUserIndent Set whether we want to ignore the additional indentation specified in parameter it.
+ *
+ * @return columnCounter.
+ */
 std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenStream* ts, TokenIt it, int currentLineTabs, bool alignComment, bool ignoreUserIndent)
 {
 	auto prevIt = ts->predecessor(it);
@@ -485,8 +497,6 @@ std::string TokenStream::getText(bool withIncludes, bool alignComments)
  * @param os The stream to be filled with the text.
  * @param withIncludes Set if includes are also to be included.
  * @param alignComments Set if comments should be aligned.
- *
- * @return Builder.
  */
 void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, bool withIncludes, bool alignComments)
 {

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -224,9 +224,9 @@ public:
 	std::size_t getTabulator() const { return _tabulator; }
 	bool putNewLines() const { return _put_new_lines; }
 private:
-	bool _put_new_lines;
-	std::size_t _tabulator;
-	std::size_t _line;
+	bool _put_new_lines; // set if this bracket requires new lines in its sector.
+	std::size_t _tabulator; // the level of indentation inside of the bracket's sector.
+	std::size_t _line; // Which line is the bracket on.
 };
 
 
@@ -439,9 +439,9 @@ std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenS
 	auto indentation = it->getIndentation() + 1;
 
 	const std::string& indent = it->getLiteral().getFormattedValue();
-	// Comment at a beginning of a line
 	if (ss)
 	{
+		// Comment at a beginning of a line
 		if (!prevIt || (*prevIt)->getType() == NEW_LINE)
 		{
 			*ss << indent;
@@ -449,7 +449,7 @@ std::size_t TokenStream::PrintHelper::printComment(std::stringstream* ss, TokenS
 		else if (alignComment && columnCounter < indentation && (!prevIt || (*prevIt)->getType() != COLON))
 			*ss << std::string(indentation - columnCounter, ' ');
 		*ss << it->getPureText();
-	}
+	} /*  */
 	else if (it->getType() == ONELINE_COMMENT && (!prevIt || (*prevIt)->getType() != COLON))
 	{
 		commentOnThisLine = true;
@@ -478,7 +478,9 @@ std::string TokenStream::getText(bool withIncludes, bool alignComments)
  * os == nullptr.
  *
  * @param helper The expression to enclose.
- * @param linebreak Put linebreak after opening and before closing parenthesis and indent content by one more level.
+ * @param os The stream to be filled with the text.
+ * @param withIncludes Set if includes are also to be included.
+ * @param alignComments Set if comments should be aligned.
  *
  * @return Builder.
  */

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -708,7 +708,7 @@ rule rule_with_range
 
 TEST_F(BuilderTests,
 RuleWithConditionWithMultilineComment) {
-	auto cond = (id("pe").comment("Number of sections needs to exceed 1,\nbecause one is simply not enough.", true).access("number_of_sections") > intVal(1)).get();
+	auto cond = (id("pe").comment("Number of sections needs to exceed 1,\n\t\tbecause one is simply not enough.", true).access("number_of_sections") > intVal(1)).get();
 
 	YaraRuleBuilder newRule;
 	auto rule = newRule
@@ -1324,7 +1324,7 @@ RuleWithCommentedDisjunctionInConditionWorks) {
 	terms.emplace_back(std::make_pair(stringRef("$2"), "World must be present"));
 	terms.emplace_back(std::make_pair(paren(entrypoint() == intVal(100)), "entrypoint is 100"));
 
-	auto cond = disjunction(terms).get();
+	auto cond = conjunction({boolVal(true), paren(disjunction(terms))}).get();
 
 	YaraRuleBuilder newRule;
 	auto rule = newRule
@@ -1345,9 +1345,9 @@ RuleWithCommentedDisjunctionInConditionWorks) {
 		$1 = "Hello"
 		$2 = "World"
 	condition:
-		$1 or
+		true and ($1 or
 		$2 or
-		(entrypoint == 100)
+		(entrypoint == 100))
 })", yaraFile->getText());
 
 	EXPECT_EQ(R"(rule rule_with_commented_disjunction
@@ -1356,12 +1356,15 @@ RuleWithCommentedDisjunctionInConditionWorks) {
 		$1 = "Hello"
 		$2 = "World"
 	condition:
-		/* Hello must be present */
-		$1 or
-		/* World must be present */
-		$2 or
-		/* entrypoint is 100 */
-		(entrypoint == 100)
+		true and
+		(
+			/* Hello must be present */
+			$1 or
+			/* World must be present */
+			$2 or
+			/* entrypoint is 100 */
+			(entrypoint == 100)
+		)
 }
 )", yaraFile->getTextFormatted());
 }

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4515,8 +4515,7 @@ import "cuckoo"
 rule public_rule
 {
 	condition:
-			(false and
-			true )
+			( /* comment */ false and true )
 }
 )");
 	EXPECT_TRUE(driver.parse(input));
@@ -4530,7 +4529,7 @@ rule public_rule
 {
 	condition:
 		(
-			false and
+			/* comment */ false and
 			true
 		)
 }
@@ -4809,16 +4808,19 @@ R"(import "cuckoo"
 
 rule abc
 {
+	// Strings:
 	strings:
-				// Comments
+		// Comment s01
 			$s01 = "Hello"
-			/* comment */
+			/* comment s02 */
 			$s02 = "Yaragen"
+				//comment after s02
+	// A very important condition:
 	condition:
-	(
-		// Cuckoo
+	true or	(
+				// Cuckoo
 			$s01 or
-		/* Gvma */
+	/* Gvma */
 			$s02
 		)
 }
@@ -4831,12 +4833,70 @@ R"(import "cuckoo"
 
 rule abc
 {
+	// Strings:
 	strings:
-		// Comments
+		// Comment s01
 		$s01 = "Hello"
-		/* comment */
+		/* comment s02 */
 		$s02 = "Yaragen"
+		//comment after s02
+	// A very important condition:
 	condition:
+		true or
+		(
+			// Cuckoo
+			$s01 or
+			/* Gvma */
+			$s02
+		)
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+AutoformattingAlignedComments3) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+// Strings:
+	strings:
+				/* Comment s01 */
+			$s01 = "Hello"
+			// comment s02
+			$s02 = "Yaragen"
+		/* comment after s02 */
+// A very important condition:
+	condition:
+	true or	(
+// Cuckoo
+			$s01 or
+	/* Gvma */
+			$s02
+		)
+}
+)");
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	std::string expected =
+R"(import "cuckoo"
+
+rule abc
+{
+// Strings:
+	strings:
+		/* Comment s01 */
+		$s01 = "Hello"
+		// comment s02
+		$s02 = "Yaragen"
+		/* comment after s02 */
+// A very important condition:
+	condition:
+		true or
 		(
 			// Cuckoo
 			$s01 or

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4803,6 +4803,53 @@ rule rule1
 }
 
 TEST_F(ParserTests,
+AutoformattingAlignedComments2) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	strings:
+				// Comments
+			$s01 = "Hello"
+			/* comment */
+			$s02 = "Yaragen"
+	condition:
+	(
+		// Cuckoo
+			$s01 or
+		/* Gvma */
+			$s02
+		)
+}
+)");
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	std::string expected =
+R"(import "cuckoo"
+
+rule abc
+{
+	strings:
+		// Comments
+		$s01 = "Hello"
+		/* comment */
+		$s02 = "Yaragen"
+	condition:
+		(
+			// Cuckoo
+			$s01 or
+			/* Gvma */
+			$s02
+		)
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 AutoformattingNewlinesMultipleRules) {
 	prepareInput(
 R"(/*

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4698,7 +4698,8 @@ rule public_rule
 		false or
 		( //comment 1
 			true and
-			( /*comment 2*/
+			(
+				/*comment 2*/
 				cuckoo.network.http_request(/http(s)?:\/\/(www\.)?brokolice\.cz/) or
 				cuckoo.network.http_request(/http(s)?:\/\/(www\.)?kvetak\.cz/)
 			) //comment 3


### PR DESCRIPTION
This PR implements autoformatting [improvement](https://github.com/avast/yaramod/wiki/Autoformatting#indenting-comments-inside-rule-sections) and also improves commented conjunctions / disjunctions produced in builder.