### PR TITLE
Fix addMeta, removeMetas and setTags handle of TokenStream

### DIFF
--- a/include/yaramod/types/meta.h
+++ b/include/yaramod/types/meta.h
@@ -21,7 +21,9 @@ class Meta
 public:
 	/// @name Constructors
 	/// @{
-	Meta(TokenIt key, TokenIt value) : _key(key), _value(value) {}
+	Meta(TokenIt key, TokenIt value) : _key(key), _value(value)
+	{
+	}
 	Meta(const Meta& meta) = default;
 	Meta(Meta&& meta) = default;
 	/// @}
@@ -40,7 +42,9 @@ public:
 	/// @name Getter methods
 	/// @{
 	const std::string& getKey() const;
+	TokenIt getKeyTokenIt() const;
 	const Literal& getValue() const;
+	TokenIt getValueTokenIt() const;
 	/// @}
 
 	/// @name Setter methods

--- a/include/yaramod/types/meta.h
+++ b/include/yaramod/types/meta.h
@@ -21,9 +21,7 @@ class Meta
 public:
 	/// @name Constructors
 	/// @{
-	Meta(TokenIt key, TokenIt value) : _key(key), _value(value)
-	{
-	}
+	Meta(TokenIt key, TokenIt value) : _key(key), _value(value) {}
 	Meta(const Meta& meta) = default;
 	Meta(Meta&& meta) = default;
 	/// @}

--- a/src/types/meta.cpp
+++ b/src/types/meta.cpp
@@ -29,6 +29,16 @@ const std::string& Meta::getKey() const
 }
 
 /**
+ * Returns the token iterator of the key of a single meta information.
+ *
+ * @return Key.
+ */
+TokenIt Meta::getKeyTokenIt() const
+{
+	return _key;
+}
+
+/**
  * Returns the value of a single meta information.
  *
  * @return Value.
@@ -36,6 +46,16 @@ const std::string& Meta::getKey() const
 const Literal& Meta::getValue() const
 {
 	return _value->getLiteral();
+}
+
+/**
+ * Returns the token iterator of the value of a single meta information.
+ *
+ * @return Key.
+ */
+TokenIt Meta::getValueTokenIt() const
+{
+	return _value;
 }
 
 /**

--- a/src/types/token.cpp
+++ b/src/types/token.cpp
@@ -16,7 +16,7 @@ namespace yaramod {
 
 const Literal& Token::getLiteral() const
 {
-	assert(_value);
+	assert("Literal is not nullptr" && _value);
 	return *_value;
 }
 

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -4050,8 +4050,6 @@ private rule RULE_1
 	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
 
-
-
 TEST_F(ParserTests,
 ForCycleMultipleRowsWithCRLF)
 {
@@ -4239,6 +4237,161 @@ rule nonutf_condition
 }
 )";
 
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+AddMetaAfterParse) {
+	prepareInput(
+R"(
+rule rule_1
+{
+	condition:
+		true
+}
+
+
+rule rule_2
+{
+	strings:
+		$s0 = "string 0"
+	condition:
+		$s0
+}
+
+
+rule rule_3
+{
+	meta:
+		author = "Mr. Avastian"
+	condition:
+		false
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	const auto& rules = driver.getParsedFile().getRules();
+	EXPECT_EQ(rules.size(), 3);
+
+	auto rule = rules[0];
+	ASSERT_EQ(0u, rule->getMetas().size());
+	uint64_t u = 42;
+	rule->addMeta("new_int_meta", Literal(u));
+	ASSERT_EQ(1u, rule->getMetas().size());
+	EXPECT_TRUE(rule->getMetas()[0].getValue().isInt());
+	EXPECT_EQ(42, rule->getMetas()[0].getValue().getInt());
+	EXPECT_EQ(R"(42)", rule->getMetas()[0].getValue().getText());
+
+	rule = rules[1];
+	ASSERT_EQ(0u, rule->getMetas().size());
+	rule->addMeta("new_string_meta", Literal("string value"));
+	ASSERT_EQ(1u, rule->getMetas().size());
+	EXPECT_TRUE(rule->getMetas()[0].getValue().isString());
+	EXPECT_EQ(R"("string value")", rule->getMetas()[0].getValue().getText());
+
+	rule = rules[2];
+	ASSERT_EQ(1u, rule->getMetas().size());
+	rule->addMeta("new_bool_meta", Literal(true));
+	ASSERT_EQ(2u, rule->getMetas().size());
+	const Meta* meta = rule->getMetaWithName("new_bool_meta");
+	ASSERT_NE(meta, nullptr);
+	EXPECT_EQ(meta->getKey(), "new_bool_meta");
+	EXPECT_TRUE(meta->getValue().isBool());
+	EXPECT_TRUE(meta->getValue().getBool());
+	EXPECT_EQ(meta->getValue().getText(), "true");
+
+std::string expected = R"(
+rule rule_1
+{
+	meta:
+		new_int_meta = 42
+	condition:
+		true
+}
+
+
+rule rule_2
+{
+	meta:
+		new_string_meta = "string value"
+	strings:
+		$s0 = "string 0"
+	condition:
+		$s0
+}
+
+
+rule rule_3
+{
+	meta:
+		author = "Mr. Avastian"
+		new_bool_meta = true
+	condition:
+		false
+}
+)";
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+SetTagsAfterParse) {
+	prepareInput(
+R"(
+rule rule_1 {
+	condition:
+		true
+}
+
+rule rule_2
+{
+	condition:
+		true
+}
+
+rule rule_3 : TagA {
+	strings:
+		$s0 = "string 0"
+	condition:
+		$s0
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	const auto& rules = driver.getParsedFile().getRules();
+	EXPECT_EQ(rules.size(), 3);
+
+	auto rule = rules[0];
+	std::vector<std::string> tags = {"Tag1", "Tag2"};
+	rule->setTags(tags);
+
+	rule = rules[1];
+	rule->setTags(tags);
+
+	rule = rules[2];
+	tags = {"TagB", "TagC"};
+	rule->setTags(tags);
+
+std::string expected = R"(
+rule rule_1 : Tag1 Tag2
+{
+	condition:
+		true
+}
+
+rule rule_2 : Tag1 Tag2
+{
+	condition:
+		true
+}
+
+rule rule_3 : TagB TagC
+{
+	strings:
+		$s0 = "string 0"
+	condition:
+		$s0
+}
+)";
 	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
 


### PR DESCRIPTION
This PR fixes some less frequently used `Rule` methods that we recently found out misbehave. The problem is that these methods `Rule::addMeta`, `Rule::addTags` and `Rule::removeMetas` did not handle the TokenStream well and left the formatted text unchanged. In this PR we fix these methods, however there are still quite some methods left unfixed. These methods shall be fixed in the future in the issue #84.