### PR TITLE
Fix conjunction placement

### DIFF
--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -320,15 +320,13 @@ bool TokenStream::determineNewlineSectors()
 			{
 				if (lastMoved == NEW_LINE && pre_it->getType() == NEW_LINE)
 				{
-					erase(pre_it);
-					--pre_it;
+					pre_it = std::prev(erase(pre_it));
 				}
 				else
 				{
 					insert_before = _tokens.emplace(insert_before, std::move(*pre_it));
-					erase(pre_it);
+					pre_it = std::prev(erase(pre_it));
 					lastMoved = insert_before->getType();
-					--pre_it;
 				}
 			}
 		}

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3289,9 +3289,17 @@ rule rule_3
 	condition:
 		//cuckoo
 		cuckoo.sync.mutex(/a/)
+		
 		or cuckoo.sync.mutex(/b/)
+		
 		//cuckoo 64-bit
-		or cuckoo.sync.mutex(/c/)
+
+	
+		and cuckoo.sync.mutex(/c/)
+
+
+
+
 		or cuckoo.sync.mutex(/d/)
 }
 )");
@@ -3318,7 +3326,7 @@ rule rule_2 {
 
 rule rule_3 {
 	condition:
-		cuckoo.sync.mutex(/a/) or cuckoo.sync.mutex(/b/) or cuckoo.sync.mutex(/c/) or cuckoo.sync.mutex(/d/)
+		cuckoo.sync.mutex(/a/) or cuckoo.sync.mutex(/b/) and cuckoo.sync.mutex(/c/) or cuckoo.sync.mutex(/d/)
 })", driver.getParsedFile().getText());
 
 	std::string expected = R"(
@@ -3350,7 +3358,7 @@ rule rule_3
 	condition:
 		//cuckoo
 		cuckoo.sync.mutex(/a/) or
-		cuckoo.sync.mutex(/b/) or
+		cuckoo.sync.mutex(/b/) and
 		//cuckoo 64-bit
 		cuckoo.sync.mutex(/c/) or
 		cuckoo.sync.mutex(/d/)

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3187,6 +3187,180 @@ rule rule_2
 }
 
 TEST_F(ParserTests,
+RemoveLineBeforeAndWithCommentsWorks) {
+	prepareInput(
+R"(rule rule_1 {
+	strings:
+		$1 = "plain string" wide
+		$2 = { ab cd ef }
+		$3 = /ab*c/
+	condition:
+		any of them
+		// cuckoo
+		or (
+		true
+		// gvma
+		and false)
+}
+
+rule rule_2
+{
+	condition:
+		true
+		/* cuckoo */
+		
+		or false
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(2u, driver.getParsedFile().getRules().size());
+
+	EXPECT_EQ(
+R"(rule rule_1 {
+	strings:
+		$1 = "plain string" wide
+		$2 = { AB CD EF }
+		$3 = /ab*c/
+	condition:
+		any of them or (true and false)
+}
+
+rule rule_2 {
+	condition:
+		true or false
+})", driver.getParsedFile().getText());
+
+	std::string expected = R"(rule rule_1
+{
+	strings:
+		$1 = "plain string" wide
+		$2 = { ab cd ef }
+		$3 = /ab*c/
+	condition:
+		any of them or
+		// cuckoo
+		(
+			true and
+			// gvma
+			false
+		)
+}
+
+rule rule_2
+{
+	condition:
+		true or
+		/* cuckoo */
+		false
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+RemoveLineBeforeAndWithComments2Works) {
+	prepareInput(
+R"(
+import "cuckoo"
+
+rule rule_1 {
+	strings:
+		$1 = "plain string" wide
+		$2 = { ab cd ef }
+		$3 = /ab*c/
+	condition:
+		any of them // cuckoo
+		or (
+		true // gvma
+
+		and false)
+}
+
+rule rule_2
+{
+	condition:
+		true /* cuckoo */ or false
+}
+
+rule rule_3
+{
+	condition:
+		//cuckoo
+		cuckoo.sync.mutex(/a/)
+		or cuckoo.sync.mutex(/b/)
+		//cuckoo 64-bit
+		or cuckoo.sync.mutex(/c/)
+		or cuckoo.sync.mutex(/d/)
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(3u, driver.getParsedFile().getRules().size());
+
+	EXPECT_EQ(
+R"(import "cuckoo"
+
+rule rule_1 {
+	strings:
+		$1 = "plain string" wide
+		$2 = { AB CD EF }
+		$3 = /ab*c/
+	condition:
+		any of them or (true and false)
+}
+
+rule rule_2 {
+	condition:
+		true or false
+}
+
+rule rule_3 {
+	condition:
+		cuckoo.sync.mutex(/a/) or cuckoo.sync.mutex(/b/) or cuckoo.sync.mutex(/c/) or cuckoo.sync.mutex(/d/)
+})", driver.getParsedFile().getText());
+
+	std::string expected = R"(
+import "cuckoo"
+
+rule rule_1
+{
+	strings:
+		$1 = "plain string" wide
+		$2 = { ab cd ef }
+		$3 = /ab*c/
+	condition:
+		any of them or // cuckoo
+		(
+			true and // gvma
+			false
+		)
+}
+
+rule rule_2
+{
+	condition:
+		true /* cuckoo */ or
+		false
+}
+
+rule rule_3
+{
+	condition:
+		//cuckoo
+		cuckoo.sync.mutex(/a/) or
+		cuckoo.sync.mutex(/b/) or
+		//cuckoo 64-bit
+		cuckoo.sync.mutex(/c/) or
+		cuckoo.sync.mutex(/d/)
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 MultipleRulesWorks2) {
 	prepareInput(
 R"(


### PR DESCRIPTION
In case of a conjunction preceded by some newlines and a one-line comment:
```
		true // cuckoo

		and false
```
our autoformatter wrongly created
```
		true // cuckoo and
		false
```
This is fixed in this PR, where
```
		//cuckoo
		cuckoo.sync.mutex(/a/)
		
		or cuckoo.sync.mutex(/b/)
		
		//cuckoo

	
		or cuckoo.sync.mutex(/c/)




		or cuckoo.sync.mutex(/d/)
```
becomes this
```
		//cuckoo
		cuckoo.sync.mutex(/a/) or
		cuckoo.sync.mutex(/b/) or
		//cuckoo
		cuckoo.sync.mutex(/c/) or
		cuckoo.sync.mutex(/d/)
```