### PR TITLE
New metadata module

### DIFF
--- a/include/yaramod/types/modules/metadata_module.h
+++ b/include/yaramod/types/modules/metadata_module.h
@@ -1,0 +1,35 @@
+/**
+ * @file src/types/modules/metadata_module.h
+ * @brief Declaration of MetadataModule.
+ * @copyright (c) 2017 Avast Software, licensed under the MIT license
+ */
+
+#pragma once
+
+#include "yaramod/types/modules/module.h"
+
+namespace yaramod {
+
+/**
+ * Class representing @c metadata module.
+ */
+class MetadataModule : public Module
+{
+public:
+    /// @name Constructors
+    /// @{
+    MetadataModule();
+    /// @}
+
+    /// @name Destructor
+    /// @{
+    virtual ~MetadataModule() override = default;
+    /// @}
+
+    /// @name Initialization method
+    /// @{
+    virtual bool initialize(ImportFeatures features) override;
+    /// @}
+};
+
+}

--- a/include/yaramod/types/modules/modules.h
+++ b/include/yaramod/types/modules/modules.h
@@ -15,6 +15,7 @@
 #include "yaramod/types/modules/macho_module.h"
 #include "yaramod/types/modules/magic_module.h"
 #include "yaramod/types/modules/math_module.h"
+#include "yaramod/types/modules/metadata_module.h"
 #include "yaramod/types/modules/pe_module.h"
 #include "yaramod/types/modules/phish_module.h"
 #include "yaramod/types/modules/time_module.h"

--- a/include/yaramod/types/modules/modules_pool.h
+++ b/include/yaramod/types/modules/modules_pool.h
@@ -53,6 +53,7 @@ private:
 		{ "macho",      std::make_shared<MachoModule>()      },
 		{ "magic",      std::make_shared<MagicModule>()      },
 		{ "math",       std::make_shared<MathModule>()       },
+		{ "metadata",   std::make_shared<MetadataModule>()   },
 		{ "pe",         std::make_shared<PeModule>()         },
 		{ "phish",      std::make_shared<PhishModule>()      },
 		{ "time",       std::make_shared<TimeModule>()       }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
 	types/modules/pe_module.cpp
 	types/modules/phish_module.cpp
 	types/modules/time_module.cpp
+	types/modules/metadata_module.cpp
 	types/plain_string.cpp
 	types/rule.cpp
 	types/token.cpp

--- a/src/types/modules/metadata_module.cpp
+++ b/src/types/modules/metadata_module.cpp
@@ -1,0 +1,50 @@
+/**
+ * @file src/types/modules/metadata_module.cpp
+ * @brief Implementation of MetadataModule.
+ * @copyright (c) 2017 Avast Software, licensed under the MIT license
+ */
+
+#include "yaramod/types/expression.h"
+#include "yaramod/types/modules/metadata_module.h"
+#include "yaramod/types/symbol.h"
+
+namespace yaramod {
+
+/**
+ * Constructor.
+ */
+MetadataModule::MetadataModule() : Module("metadata", ImportFeatures::Basic)
+{
+}
+
+/**
+ * Initializes module structure.
+ *
+ * @return @c true if success, otherwise @c false.
+ */
+bool MetadataModule::initialize(ImportFeatures features)
+{
+	using Type = Expression::Type;
+	auto metadataStruct = std::make_shared<StructureSymbol>("metadata");
+
+	auto fileStruct = std::make_shared<StructureSymbol>("file");
+	if (features & ImportFeatures::AvastOnly)
+	{
+		fileStruct->addAttribute(std::make_shared<FunctionSymbol>("name", Type::Int, Type::String));
+		fileStruct->addAttribute(std::make_shared<FunctionSymbol>("name", Type::Int, Type::Regexp));
+	}
+	metadataStruct->addAttribute(fileStruct);
+
+	auto detectionStruct = std::make_shared<StructureSymbol>("detection");
+	if (features & ImportFeatures::AvastOnly)
+	{
+		detectionStruct->addAttribute(std::make_shared<FunctionSymbol>("name", Type::Int, Type::Regexp));
+		detectionStruct->addAttribute(std::make_shared<FunctionSymbol>("name", Type::Int, Type::String, Type::Regexp));
+	}
+	metadataStruct->addAttribute(detectionStruct);
+
+	_structure = metadataStruct;
+	return true;
+}
+
+}


### PR DESCRIPTION
New module `metadata` only for Avast.

`metadata` module contains:
* `metadata.file.name("string")`
* `metadata.file.name(/regex/)`
* `metadata.detection.name(/regex/)`
* `metadata.detection.name("av_name", /regex/)`

Signed-off-by: Peter Tisovčík <peter.tisovcik@avast.com>