### PR TITLE
Fix parsing of "private global" rules

### DIFF
--- a/include/yaramod/builder/yara_rule_builder.h
+++ b/include/yaramod/builder/yara_rule_builder.h
@@ -84,7 +84,8 @@ private:
 	void createLastString();
 
 	std::shared_ptr<TokenStream> _tokenStream; ///< Storage of all Tokens
-	std::optional<TokenIt> _mod; ///< Modifier
+	std::optional<TokenIt> _mod_private; ///< Private modifier
+	std::optional<TokenIt> _mod_global; ///< Global modifier
 	std::vector<TokenIt> _tags; ///< Tags
 	std::vector<Meta> _metas; ///< Meta information
 	std::shared_ptr<Rule::StringsTrie> _strings; ///< Strings

--- a/include/yaramod/types/rule.h
+++ b/include/yaramod/types/rule.h
@@ -46,7 +46,8 @@ public:
 	{
 		None,
 		Global,
-		Private
+		Private,
+		PrivateGlobal,
 	};
 
 	/// @name Constructors
@@ -54,8 +55,8 @@ public:
 	Rule();
 	explicit Rule(std::string&& name, Modifier mod, std::vector<Meta>&& metas, std::shared_ptr<StringsTrie>&& strings,
 		Expression::Ptr&& condition, const std::vector<std::string>& tags);
-	explicit Rule(const std::shared_ptr<TokenStream>& tokenStream, TokenIt name, std::optional<TokenIt> mod, std::vector<Meta>&& metas, std::shared_ptr<StringsTrie>&& strings,
-		Expression::Ptr&& condition, const std::vector<TokenIt>& tags);
+	explicit Rule(const std::shared_ptr<TokenStream>& tokenStream, TokenIt name, std::optional<TokenIt> mod_private, std::optional<TokenIt> mod_global,
+		std::vector<Meta>&& metas, std::shared_ptr<StringsTrie>&& strings, Expression::Ptr&& condition, const std::vector<TokenIt>& tags);
 
 	Rule(Rule&& rule) = default;
 	Rule(const Rule& rule) = default;
@@ -112,7 +113,8 @@ private:
 
 	std::shared_ptr<TokenStream> _tokenStream; ///< tokenStream containing all the data in this Rule
 	TokenIt _name; ///< Name
-	std::optional<TokenIt> _mod; ///< Modifier
+	std::optional<TokenIt> _mod_private; ///< Private modifier
+	std::optional<TokenIt> _mod_global; ///< Global modifier
 	std::vector<Meta> _metas; ///< Meta information
 	std::shared_ptr<StringsTrie> _strings; ///< Strings
 	Expression::Ptr _condition; ///< Condition expression

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -81,7 +81,8 @@ void addEnums(py::module& module)
 	py::enum_<Rule::Modifier>(module, "RuleModifier")
 		.value("Empty", Rule::Modifier::None)
 		.value("Global", Rule::Modifier::Global)
-		.value("Private", Rule::Modifier::Private);
+		.value("Private", Rule::Modifier::Private)
+		.value("PrivateGlobal", Rule::Modifier::PrivateGlobal);
 
 	py::enum_<String::Type>(module, "StringType")
 		.value("Plain", String::Type::Plain)

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -1555,6 +1555,7 @@ global rule global_rule
 	const auto& rule = driver.getParsedFile().getRules()[0];
 	EXPECT_EQ("global_rule", rule->getName());
 	EXPECT_EQ(Rule::Modifier::Global, rule->getModifier());
+	EXPECT_FALSE(rule->isPrivate());
 	EXPECT_TRUE(rule->isGlobal());
 
 	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
@@ -1578,6 +1579,31 @@ private rule private_rule
 	EXPECT_EQ("private_rule", rule->getName());
 	EXPECT_EQ(Rule::Modifier::Private, rule->getModifier());
 	EXPECT_TRUE(rule->isPrivate());
+	EXPECT_FALSE(rule->isGlobal());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+
+TEST_F(ParserTests,
+PrivateGlobalRuleModifierWorks) {
+	prepareInput(
+R"(
+private global rule private_global_rule
+{
+	condition:
+		true
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ("private_global_rule", rule->getName());
+	EXPECT_EQ(Rule::Modifier::PrivateGlobal, rule->getModifier());
+	EXPECT_TRUE(rule->isPrivate());
+	EXPECT_TRUE(rule->isGlobal());
 
 	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
 }


### PR DESCRIPTION
I've went ahead and tried to fix the issue I've found. I hope my C++ is adequate.

I tried to be careful not to introduce any regressions and memory leaks, but please do check.

I've also added a test to `parser_tests.cpp` but had problems building the test suite, so I just hope the test works. I tested my fixes by hand, using the python bindings instead:

```python
import yaramod

test = """
/* comment test */
private global rule Kot
{
    strings:
        $a = "dummy1"

    condition:
        $a
}
/* comment test */
global private rule Hmm
{
    strings:
        $a = "dummy1"

    condition:
        $a
}

/* this will not work:
global global rule Zzz
{
    strings:
        $a = "dummy1"

    condition:
        $a
}
*/

private rule private_rule {
    condition:
        true
}

global rule global_rule {
    condition:
        true
}
"""

print(yaramod.Yaramod().parse_string(test).text_formatted)

for rule in yaramod.Yaramod().parse_string(test).rules:
    print(rule.name, ("private" if rule.is_private else ""), ("global" if rule.is_global else ""))
```

This test doesn't work on current master branch (as expected), but works after this PR.

Fixes #92.