### PR TITLE
Added symtab_symbol function to elf module

### DIFF
--- a/src/types/modules/elf_module.cpp
+++ b/src/types/modules/elf_module.cpp
@@ -174,6 +174,9 @@ bool ElfModule::initialize(ImportFeatures/* features*/)
 	symtabStruct->addAttribute(std::make_shared<ValueSymbol>("shndx", Type::Int));
 	elfStruct->addAttribute(std::make_shared<ArraySymbol>("symtab", symtabStruct));
 
+	elfStruct->addAttribute(std::make_unique<FunctionSymbol>("symtab_symbol", Type::Int, Type::String));
+	elfStruct->addAttribute(std::make_unique<FunctionSymbol>("symtab_symbol", Type::Int, Type::Regexp));
+
 	_structure = elfStruct;
 	return true;
 }


### PR DESCRIPTION
Added `symtab_symbol` into attributes of `elf` module.

This change is related to [this]( https://github.com/VirusTotal/yara/pull/1256/).