### PR TITLE
access to the "id" attribute in ForIntExpression (fix: #103)

### DIFF
--- a/include/yaramod/types/expressions.h
+++ b/include/yaramod/types/expressions.h
@@ -1001,6 +1001,11 @@ public:
 	{
 	}
 
+	const std::string getId() { return _id->getString(); }
+
+	void setId(const std::string& id) { _id->setValue(id); }
+	void setId(std::string& id) { _id->setValue(std::move(id)); }
+
 	virtual VisitResult accept(Visitor* v) override
 	{
 		return v->visit(this);

--- a/src/examples/cpp/dump_rules_ast/dumper.h
+++ b/src/examples/cpp/dump_rules_ast/dumper.h
@@ -309,7 +309,7 @@ public:
 
 	virtual yaramod::VisitResult visit(yaramod::ForIntExpression* expr) override
 	{
-		dump("ForInt", expr);
+		dump("ForInt", expr, " id=", expr->getId());
 		indentUp();
 		expr->getVariable()->accept(this);
 		expr->getIteratedSet()->accept(this);

--- a/src/examples/python/dump_rules_ast.py
+++ b/src/examples/python/dump_rules_ast.py
@@ -202,7 +202,7 @@ class Dumper(yaramod.ObservingVisitor):
         self.indent_down()
 
     def visit_ForIntExpression(self, expr):
-        self.dump('ForInt', expr)
+        self.dump('ForInt', expr, ' id=', expr.id)
         self.indent_up()
         expr.variable.accept(self)
         expr.iterated_set.accept(self)

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -423,7 +423,10 @@ void addExpressionClasses(py::module& module)
 		.def_property("body",
 				&ForExpression::getBody,
 				py::overload_cast<const Expression::Ptr&>(&ForExpression::setBody));
-	exprClass<ForIntExpression, ForExpression>(module, "ForIntExpression");
+	exprClass<ForIntExpression, ForExpression>(module, "ForIntExpression")
+		.def_property("id",
+				&ForIntExpression::getId,
+				py::overload_cast<const std::string&>(&ForIntExpression::setId));
 	exprClass<ForStringExpression, ForExpression>(module, "ForStringExpression");
 	exprClass<OfExpression, ForExpression>(module, "OfExpression");
 


### PR DESCRIPTION
fix for #103 , it does the job for me, not sure if there's a better way (one of the setters is technically not used, but it seemed like similar attributes had it as well).