### PR TITLE
Fix and test ForIntExpression id getter and setters (#10)

### DIFF
--- a/include/yaramod/types/expressions.h
+++ b/include/yaramod/types/expressions.h
@@ -1001,10 +1001,10 @@ public:
 	{
 	}
 
-	const std::string getId() { return _id->getString(); }
+	const std::string& getId() const { return _id->getString(); }
 
 	void setId(const std::string& id) { _id->setValue(id); }
-	void setId(std::string& id) { _id->setValue(std::move(id)); }
+	void setId(std::string&& id) { _id->setValue(std::move(id)); }
 
 	virtual VisitResult accept(Visitor* v) override
 	{

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -556,6 +556,7 @@ RuleWithConditionWithSymbolsWorks) {
 	auto forExp = std::static_pointer_cast<ForIntExpression>(cond);
 	EXPECT_EQ(forExp->getId(), "n");
 	forExp->setId("i");
+	EXPECT_EQ(forExp->getId(), "i");
 	EXPECT_EQ(cond->getText(), "for any i in (1, 2, 3) : ( $1 at (entrypoint + i) )");
 
 	YaraRuleBuilder newRule;

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -550,9 +550,13 @@ RuleWithCustomConditionWorks) {
 
 TEST_F(BuilderTests,
 RuleWithConditionWithSymbolsWorks) {
-	auto cond = forLoop(any(), "i", set({intVal(1), intVal(2), intVal(3)}), matchAt("$1", paren(entrypoint() + id("i")))).get();
+	auto cond = forLoop(any(), "n", set({intVal(1), intVal(2), intVal(3)}), matchAt("$1", paren(entrypoint() + id("i")))).get();
 	EXPECT_EQ("for", cond->getFirstTokenIt()->getPureText());
 	EXPECT_EQ(")", cond->getLastTokenIt()->getPureText());
+	auto forExp = std::static_pointer_cast<ForIntExpression>(cond);
+	EXPECT_EQ(forExp->getId(), "n");
+	forExp->setId("i");
+	EXPECT_EQ(cond->getText(), "for any i in (1, 2, 3) : ( $1 at (entrypoint + i) )");
 
 	YaraRuleBuilder newRule;
 	auto rule = newRule


### PR DESCRIPTION
This PR fixes and tests ForIntExpression::_id getter and setters which were introduced in #109. Together with #109 it solves #103.