### PR TITLE
yaramod/types/rule.h: add const getMetaWithName() version

### DIFF
--- a/include/yaramod/types/rule.h
+++ b/include/yaramod/types/rule.h
@@ -78,6 +78,7 @@ public:
 	std::vector<std::string> getTags() const;
 	const std::shared_ptr<Symbol>& getSymbol() const;
 	Meta* getMetaWithName(const std::string& key);
+	const Meta* getMetaWithName(const std::string& key) const;
 	const Location& getLocation() const;
 	TokenStream* getTokenStream() const { return _tokenStream.get(); }
 	TokenIt getFirstTokenIt() const;

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -143,7 +143,7 @@ void addBasicClasses(py::module& module)
 		.def("add_meta", &Rule::addMeta)
 		.def("remove_metas", &Rule::removeMetas)
 		.def("remove_string", &Rule::removeString)
-		.def("get_meta_with_name", &Rule::getMetaWithName, py::return_value_policy::reference)
+		.def("get_meta_with_name", py::overload_cast<const std::string&>(&Rule::getMetaWithName), py::return_value_policy::reference)
 		.def("add_tag", &Rule::addTag)
 		.def("remove_tags", py::overload_cast<const std::string&>(&Rule::removeTags));
 

--- a/src/types/rule.cpp
+++ b/src/types/rule.cpp
@@ -209,6 +209,14 @@ const std::shared_ptr<Symbol>& Rule::getSymbol() const
 }
 
 /**
+ * Non-const version of @c getMetaWithName().
+ */
+Meta* Rule::getMetaWithName(const std::string& key)
+{
+	return const_cast<Meta*>(const_cast<const Rule*>(this)->getMetaWithName(key));
+}
+
+/**
  * Returns the meta with the given key if one exists.
  *
  * @param key Key of the meta.
@@ -216,7 +224,7 @@ const std::shared_ptr<Symbol>& Rule::getSymbol() const
  * @return Pointer to meta if meta with the given key exists,
  *         @c nullptr otherwise.
  */
-Meta* Rule::getMetaWithName(const std::string& key)
+const Meta* Rule::getMetaWithName(const std::string& key) const
 {
 	for (auto& meta : _metas)
 	{
@@ -436,7 +444,7 @@ void Rule::addMeta(const std::string& name, const Literal& value)
 		++insert_before;
 	}
 	_tokenStream->emplace(insert_before, TokenType::NEW_LINE, _tokenStream->getNewLineStyle());
-	auto itKey = _tokenStream->emplace(insert_before, TokenType::META_KEY, name);	
+	auto itKey = _tokenStream->emplace(insert_before, TokenType::META_KEY, name);
 	_tokenStream->emplace(insert_before, TokenType::EQ, "=");
 	auto itValue = _tokenStream->emplace(insert_before, TokenType::META_VALUE, value);
 


### PR DESCRIPTION
Code duplication avoided by using: https://stackoverflow.com/questions/856542/elegant-solution-to-duplicate-const-and-non-const-getters
However, it might have its downsides.

RetDec heavily uses `const getMetaWithName()` because it does not need to modify anything. I would have to refactor a lot of code just to remove all `const`, which does not seem right.

If you don't object, I would like to have this in Yaramod.