### PR TITLE
Fix Trie::getValueWithPrefix to return values in the correct order

### DIFF
--- a/include/yaramod/utils/trie.h
+++ b/include/yaramod/utils/trie.h
@@ -368,7 +368,7 @@ public:
 				nodes.push_back(subnode);
 		}
 
-		return result;
+		return {result.rbegin(), result.rend()};
 	}
 
 	/**

--- a/include/yaramod/utils/trie.h
+++ b/include/yaramod/utils/trie.h
@@ -368,7 +368,9 @@ public:
 				nodes.push_back(subnode);
 		}
 
-		return {result.rbegin(), result.rend()};
+		std::reverse(result.begin(), result.end());
+
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
Fixed the order of results from `Trie::getValueWithPrefix`.