### PR TITLE
Fixed issues with older compilers not providing symbols for std::filesystem functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,15 @@ option(YARAMOD_DOCS     "Build doxygen documentation for yaramod" OFF)
 option(YARAMOD_PYTHON   "Build Python extension" OFF)
 option(YARAMOD_EXAMPLES "Build examples" OFF)
 
+# Add CMake module path.
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
 # Requirements.
 include(GNUInstallDirs)
 if(YARAMOD_DOC)
 	find_package(Doxygen)
 endif()
+find_package(Filesystem)
 
 # Variables.
 set(YARAMOD_DOC_DIR     "${PROJECT_SOURCE_DIR}/doc")

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -1,0 +1,23 @@
+# Finder for C++ filesystem library.
+#
+# Ensures that stdc++fs or c++fs is used when needed
+# by the compiler.
+
+
+if(NOT TARGET Filesystem::Filesystem)
+	add_library(Filesystem::Filesystem INTERFACE IMPORTED)
+
+	# Clang
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+		# Clang older than 9.x needs -lc++fs
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+			target_link_libraries(Filesystem::Filesystem INTERFACE c++fs)
+		endif()
+	# GCC
+	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		# GCC older than 9.x needs -lstdc++fs
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+			target_link_libraries(Filesystem::Filesystem INTERFACE stdc++fs)
+		endif()
+	endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,9 @@ if(NOT TARGET yaramod)
 	# Pog library
 	target_link_libraries(yaramod pog)
 
+	# Filesystem library.
+	target_link_libraries(yaramod Filesystem::Filesystem)
+
 	# Python module.
 	if(YARAMOD_PYTHON)
 		add_subdirectory(python)


### PR DESCRIPTION
Older GCC needs to be linked against stdc++fs and Clang against c++fs.