### PR TITLE
Include filesystem based on available filesystem library

### DIFF
--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -11,13 +11,13 @@ if(NOT TARGET Filesystem::Filesystem)
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		# Clang older than 9.x needs -lc++fs
 		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-			target_link_libraries(Filesystem::Filesystem INTERFACE c++fs)
+			set_target_properties(Filesystem::Filesystem PROPERTIES INTERFACE_LINK_LIBRARIES c++fs)
 		endif()
 	# GCC
 	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		# GCC older than 9.x needs -lstdc++fs
 		if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-			target_link_libraries(Filesystem::Filesystem INTERFACE stdc++fs)
+			set_target_properties(Filesystem::Filesystem PROPERTIES INTERFACE_LINK_LIBRARIES stdc++fs)
 		endif()
 	endif()
 endif()

--- a/include/yaramod/types/modules/module_pool.h
+++ b/include/yaramod/types/modules/module_pool.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include "yaramod/utils/filesystem.h"
 #include "yaramod/types/features.h"
 #include "yaramod/types/modules/generated/module_list.h"
 #include "yaramod/types/modules/module.h"
 
-#include <filesystem>
 #include <map>
 
 namespace yaramod {
@@ -49,7 +49,7 @@ public:
 
 private:
 	void _init(const std::string& directory);
-	bool _processPath(std::filesystem::path path);
+	bool _processPath(fs::path path);
 	void _processModuleContent(const ModuleContent& content);
 	Features _features;
 	std::unordered_map<std::string, std::shared_ptr<Module>> _knownModules = {}; ///< Table of all known modules

--- a/include/yaramod/utils/filesystem.h
+++ b/include/yaramod/utils/filesystem.h
@@ -1,0 +1,23 @@
+/**
+ * @file include/yaramod/utils/filesystem.h
+ * @brief Wrapper for conditional include of C++17 filesystem feature.
+ * @copyright (c) 2021 Avast Software, licensed under the MIT license
+ */
+
+#ifndef YARAMOD_UTILS_FILESYSTEM_H
+#define YARAMOD_UTILS_FILESYSTEM_H
+
+#if __has_include(<filesystem>)
+	#include <filesystem>
+	namespace fs = std::filesystem;
+
+#elif __has_include(<experimental/filesystem>)
+	#include <experimental/filesystem>
+	namespace fs = std::experimental::filesystem;
+
+#else
+	#error "Compiler does not have C++17 filesystem feature."
+
+#endif
+
+#endif

--- a/include/yaramod/utils/filesystem_operations.h
+++ b/include/yaramod/utils/filesystem_operations.h
@@ -1,5 +1,5 @@
 /**
- * @file src/utils/filesystem.h
+ * @file include/yaramod/utils/filesystem_operations.h
  * @brief Declaration of filesystem functions.
  * @copyright (c) 2017 Avast Software, licensed under the MIT license
  */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCES
 	types/token_stream.cpp
 	types/yara_file.cpp
 	utils/json.cpp
-	utils/filesystem.cpp
+	utils/filesystem_operations.cpp
 	utils/utils.cpp
 	yaramod.cpp
 )

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -10,7 +10,7 @@
 #include "yaramod/types/hex_string.h"
 #include "yaramod/types/regexp.h"
 #include "yaramod/types/token_type.h"
-#include "yaramod/utils/filesystem.h"
+#include "yaramod/utils/filesystem_operations.h"
 
 // Uncomment for advanced debugging with HtmlReport:
 // #include <pog/html_report.h>

--- a/src/types/modules/module_pool.cpp
+++ b/src/types/modules/module_pool.cpp
@@ -48,7 +48,7 @@ std::map<std::string, Module*> ModulePool::getModules() const
 	return m;
 }
 
-bool ModulePool::_processPath(std::filesystem::path p)
+bool ModulePool::_processPath(fs::path p)
 {
 	if (p.extension() != ".cpp" && p.extension() != ".json")
 		return false;
@@ -108,7 +108,7 @@ void ModulePool::_init(const std::string& directory)
 			throw ModuleError("Error: Both YARAMOD_MODULE_SPEC_PATH and YARAMOD_MODULE_SPEC_PATH_EXCLUSIVE environment properties are set.");
 		std::stringstream paths{envProperty};
 		for (std::string path; std::getline(paths, path, ':'); )
-			_processPath(std::filesystem::path(path));
+			_processPath(fs::path(path));
 	}
 	else
 	{
@@ -118,7 +118,7 @@ void ModulePool::_init(const std::string& directory)
 			std::stringstream paths{envProperty};
 			for (std::string path; std::getline(paths, path, ':'); )
 			{
-				bool result = _processPath(std::filesystem::path(path));
+				bool result = _processPath(fs::path(path));
 				foundModules = foundModules || result;
 			}
 			if (!foundModules)
@@ -126,7 +126,7 @@ void ModulePool::_init(const std::string& directory)
 		}
 		if (directory != "")
 		{
-			for (const auto& entry : std::filesystem::directory_iterator(directory))
+			for (const auto& entry : fs::directory_iterator(directory))
 			{
 				bool result = _processPath(entry.path());
 				foundModules = foundModules || result;

--- a/src/utils/filesystem_operations.cpp
+++ b/src/utils/filesystem_operations.cpp
@@ -1,5 +1,5 @@
 /**
- * @file src/utils/filesystem.cpp
+ * @file src/utils/filesystem_operations.cpp
  * @brief Definition of filesystem functions.
  * @copyright (c) 2017 Avast Software, licensed under the MIT license
  */
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #endif
 
-#include "yaramod/utils/filesystem.h"
+#include "yaramod/utils/filesystem_operations.h"
 #include "yaramod/utils/utils.h"
 
 namespace yaramod {


### PR DESCRIPTION
We use either `std::experimental::filesystem` or `std::filesystem` depending on their availability.