### PR TITLE
Parsing of incomplete rules

### DIFF
--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -38,7 +38,8 @@ namespace yaramod {
 enum class ParserMode
 {
 	Regular, ///< In this mode, parser behaves like regular YARA parser
-	IncludeGuarded ///< Parser provides protection against inclusion of the same file multiple times
+	IncludeGuarded, ///< Parser provides protection against inclusion of the same file multiple times
+	Incomplete ///< Parser enables to parse incomplete rules: referencing unknown symbols or rules that have been not finished properly (e.g. "rule abc {strings:")
 };
 
 /**

--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -119,6 +119,11 @@ protected:
 	void reset(ParserMode parserMode);
 	/// @}
 
+	/// @name Method for obtaining info about parser
+	/// @{
+	bool incompleteMode() const { return _mode == ParserMode::Incomplete; }
+	/// @}
+
 	/// @name Methods for handling includes
 	/// @{
 	bool includeFile(const std::string& includePath, const std::shared_ptr<TokenStream>& tokenStream);

--- a/include/yaramod/types/expressions.h
+++ b/include/yaramod/types/expressions.h
@@ -985,7 +985,7 @@ protected:
  *
  * For example:
  * @code
- * for all k, v in dome_dict : (  k == "foo" and v == "bar" }
+ * for all k, v in dome_dict : (  k == "foo" and v == "bar" )
  * @endcode
  */
 class ForDictExpression : public ForExpression

--- a/include/yaramod/types/symbol.h
+++ b/include/yaramod/types/symbol.h
@@ -34,7 +34,8 @@ public:
 		Dictionary,
 		Function,
 		Structure,
-		Reference
+		Reference,
+		Undefined
 	};
 
 	/// @name Destructor
@@ -58,6 +59,7 @@ public:
 			case Type::Function : return TokenType::FUNCTION_SYMBOL;
 			case Type::Structure : return TokenType::STRUCTURE_SYMBOL;
 			case Type::Reference : return TokenType::REFERENCE_SYMBOL;
+			case Type::Undefined : return TokenType::UNDEFINED;
 			default: return TokenType::INVALID;
 		}
 	}
@@ -77,6 +79,7 @@ public:
 	bool isFunction() const { return _type == Symbol::Type::Function; }
 	bool isStructure() const { return _type == Symbol::Type::Structure; }
 	bool isReference() const { return _type == Symbol::Type::Reference; }
+	bool isUndefined() const { return _type == Symbol::Type::Undefined; }
 	/// @}
 
 protected:

--- a/include/yaramod/types/symbol.h
+++ b/include/yaramod/types/symbol.h
@@ -38,6 +38,14 @@ public:
 		Undefined
 	};
 
+	/// @name Constructors
+	/// @{
+	Symbol(Symbol::Type type, const std::string& name, ExpressionType dataType, const std::string& documentation = "")
+		: _type(type), _name(name), _documentation(documentation), _dataType(dataType)
+	{
+	}
+	/// @}
+
 	/// @name Destructor
 	/// @{
 	virtual ~Symbol() = default;
@@ -83,13 +91,6 @@ public:
 	/// @}
 
 protected:
-	/// @name Constructors
-	/// @{
-	Symbol(Symbol::Type type, const std::string& name, ExpressionType dataType, const std::string& documentation = "")
-		: _type(type), _name(name), _documentation(documentation), _dataType(dataType)
-	{
-	}
-	/// @}
 
 	Symbol::Type _type; ///< Type of the symbol
 	std::string _name; ///< Name

--- a/include/yaramod/types/token_type.h
+++ b/include/yaramod/types/token_type.h
@@ -13,6 +13,7 @@ namespace yaramod {
  */
 enum class TokenType
 {
+	UNDEFINED,
 	RULE_NAME,
 	TAG,
 	HEX_ALT, // '|'

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -12,6 +12,8 @@
 #include "yaramod/types/token_type.h"
 #include "yaramod/utils/filesystem_operations.h"
 
+#include <iostream>
+
 // Uncomment for advanced debugging with HtmlReport:
 // #include <pog/html_report.h>
 
@@ -1640,7 +1642,6 @@ void ParserDriver::defineGrammar()
 				else
 				{
 					// TODODONE: add new symbol undefined/unknown
-					std::cout << "Creating new unknown symbol '" << symbol_token->getString() << "'" << std::endl;
 					symbol = std::make_shared<Symbol>(Symbol::Type::Undefined, symbol_token->getString(), ExpressionType::Undefined);
 				}
 			}
@@ -2056,7 +2057,18 @@ bool ParserDriver::parse(std::istream& stream, ParserMode parserMode)
 
 	_fileContexts.emplace_back(&stream);
 	_file = YaraFile(currentFileContext()->getTokenStream(), _features);
-	return parseImpl();
+	try {
+		auto output = parseImpl();
+		return output;
+	} catch (const ParserError& e) {
+		if (!incompleteMode())
+			throw e;
+		else
+		{
+			std::cerr << "Warning: '" << e.getErrorMessage() << "'\nThis Warning would be an Error if not parsing in Incomplete mode." << std::endl;
+			return true;
+		}
+	}
 }
 
 bool ParserDriver::parse(const std::string& filePath, ParserMode parserMode)

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -2315,8 +2315,6 @@ void ParserDriver::checkStringModifier(const std::vector<std::shared_ptr<StringM
 		{
 			error_handle(newMod->getTokenRange().first->getLocation(), "Can not specify multiple alphabets for base64 modifiers");
 		}
-
-
 	}
 }
 

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1602,7 +1602,15 @@ void ParserDriver::defineGrammar()
 			TokenIt symbol_token = args[0].getTokenIt();
 			auto symbol = findSymbol(symbol_token->getString());
 			if (!symbol)
-				error_handle(args[0].getTokenIt()->getLocation(), "Unrecognized identifier '" + args[0].getTokenIt()->getPureText() + "' referenced");
+			{
+				if (_mode != ParserMode::Incomplete)
+					error_handle(args[0].getTokenIt()->getLocation(), "Unrecognized identifier '" + args[0].getTokenIt()->getPureText() + "' referenced");
+				else
+				{
+					error_handle(args[0].getTokenIt()->getLocation(), "TODO remove this exception '" + args[0].getTokenIt()->getPureText() + "' referenced");
+					//TODO: add new symbol with flag undefined
+				}
+			}
 			symbol_token->setValue(symbol);
 			auto output = std::make_shared<IdExpression>(symbol_token);
 			output->setType(symbol->getDataType());

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -12,8 +12,6 @@
 #include "yaramod/types/token_type.h"
 #include "yaramod/utils/filesystem_operations.h"
 
-#include <iostream>
-
 // Uncomment for advanced debugging with HtmlReport:
 // #include <pog/html_report.h>
 
@@ -2030,10 +2028,7 @@ bool ParserDriver::parse(std::istream& stream, ParserMode parserMode)
 		if (!incompleteMode())
 			throw e;
 		else
-		{
-			std::cerr << "Warning: '" << e.getErrorMessage() << "'\nThis Warning would be an Error if not parsing in Incomplete mode." << std::endl;
 			return true;
-		}
 	}
 }
 

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -172,11 +172,6 @@ void ParserDriver::defineTokens()
 		{
 			if (!incompleteMode())
 				error_handle(currentFileContext()->getLocation(), "Unable to include file '" + filePath + "'");
-			else
-			{
-				error_handle(currentFileContext()->getLocation(), "TODO: Remove this issue Unable to include file '" + filePath + "'");
-				// TODO:
-			}
 		}
 
 		return includeToken;

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1635,8 +1635,9 @@ void ParserDriver::defineGrammar()
 					error_handle(args[0].getTokenIt()->getLocation(), "Unrecognized identifier '" + args[0].getTokenIt()->getPureText() + "' referenced");
 				else
 				{
-					error_handle(args[0].getTokenIt()->getLocation(), "TODO remove this exception '" + args[0].getTokenIt()->getPureText() + "' referenced");
-					//TODO: add new symbol undefined/unknown
+					// TODODONE: add new symbol undefined/unknown
+					std::cout << "Creating new unknown symbol '" << symbol_token->getString() << "'" << std::endl;
+					symbol = std::make_shared<Symbol>(Symbol::Type::Undefined, symbol_token->getString(), ExpressionType::Undefined);
 				}
 			}
 			symbol_token->setValue(symbol);

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -432,7 +432,6 @@ void ParserDriver::defineGrammar()
 			{
 				if (!incompleteMode())
 					error_handle(import->getLocation(), "Unrecognized module '" + import->getString() + "' imported");
-				// 	error_handle(import->getLocation(), "TODODONE: remove problem with unrecognized module");
 			}
 			return {};
 		})
@@ -1081,9 +1080,9 @@ void ParserDriver::defineGrammar()
 						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array");
 					else
 					{
-						// TODO: check that parentSymbol is Undefined and replace it with ArraySymbol.
-						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array. TODO11: Check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.");
-						
+						auto parentExpr = std::static_pointer_cast<IdExpression>(iterable);
+						const auto& parentTokenText = parentExpr->getSymbolToken()->getText();
+						parentExpr->setSymbol(std::make_shared<ArraySymbol>(parentTokenText, ExpressionType::Undefined));
 					}
 				}
 

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1150,7 +1150,7 @@ void ParserDriver::defineGrammar()
 				if (!addLocalSymbol(symbol1))
 					error_handle(args[2].getTokenIt()->getLocation(), "Redefinition of identifier '" + args[2].getTokenIt()->getString() + "'");
 
-				std::shared_ptr<const ArraySymbol> iterParentSymbol = std::static_pointer_cast<const ArraySymbol>(parentSymbol);
+				std::shared_ptr<const DictionarySymbol> iterParentSymbol = std::static_pointer_cast<const DictionarySymbol>(parentSymbol);
 
 				std::shared_ptr<Symbol> symbol2;
 				if (iterParentSymbol->isStructured())

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1080,12 +1080,13 @@ void ParserDriver::defineGrammar()
 				assert(parentSymbol);
 				if (!parentSymbol->isArray())
 				{
-					if (!incompleteMode())
+					if (!incompleteMode() || !parentSymbol->isUndefined())
 						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array");
 					else
 					{
-						// TODO: check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.
+						// TODO: check that parentSymbol is Undefined and replace it with ArraySymbol.
 						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array. TODO11: Check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.");
+						
 					}
 				}
 
@@ -1133,12 +1134,15 @@ void ParserDriver::defineGrammar()
 				assert(parentSymbol);
 				if (!parentSymbol->isDictionary())
 				{
-					if (!incompleteMode())
+					if (!incompleteMode() || !parentSymbol->isUndefined())
 						error_handle((++args[5].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an dictionary");
 					else
 					{
-						// TODO: check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.
-						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an dictionary. TODO: Check that parentSymbol is UnknownSymbol and replace it with dictionary.");
+						// TODO: check that parentSymbol is Undefined and replace it with DictionarySymbol.
+						// error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an dictionary. TODO12: Check that parentSymbol is UnknownSymbol and replace it with dictionary.");
+						auto parentExpr = std::static_pointer_cast<IdExpression>(iterable);
+						const auto& parentTokenText = parentExpr->getSymbolToken()->getText();
+						parentExpr->setSymbol(std::make_shared<DictionarySymbol>(parentTokenText, ExpressionType::Undefined));
 					}
 				}
 
@@ -1673,6 +1677,7 @@ void ParserDriver::defineGrammar()
 				{
 					error_handle((--args[1].getTokenIt())->getLocation(), "TODO3 remove this exception '" + parentSymbol->getName()  + "' referenced. Create new structure symbol and replace the unknown symbol.");
 					//TODO: replace the undefined/unknown symbol with structure
+
 				}
 			}
 			auto structParentSymbol = std::static_pointer_cast<StructureSymbol>(parentSymbol);

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1706,8 +1706,9 @@ void ParserDriver::defineGrammar()
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + expr->getText() + "' is not an object");
 				else
 				{
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
-					//TODO: replace the undefined/unknown symbol with object
+					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO5 remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
+					// TODODONE: replace the undefined/unknown symbol with object
+					expr->setType(ExpressionType::Object);
 				}
 			}
 			std::shared_ptr<Symbol> parentSymbol = std::static_pointer_cast<const IdExpression>(expr)->getSymbol();
@@ -1718,12 +1719,14 @@ void ParserDriver::defineGrammar()
 
 			if (!parentSymbol->isArray() && !parentSymbol->isDictionary())
 			{
+				const auto& parentSymbolName = parentSymbol->getName();
 				if (!incompleteMode() || !parentSymbol->isUndefined())
-					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array nor dictionary");
+					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbolName + "' is not an array nor dictionary");
 				else
 				{
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
-					//TODO: replace the undefined/unknown symbol with object
+					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO6 remove this exception '" + parentSymbolName + "' referenced. Create new object symbol and replace the unknown symbol.");
+					parentSymbol = std::make_shared<ArraySymbol>(parentSymbolName, ExpressionType::Undefined);
+					//TODO: What if we are dealing with structured symbol?
 				}
 			}
 
@@ -1749,7 +1752,7 @@ void ParserDriver::defineGrammar()
 				else
 				{
 					//TODO
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO: replace unknown with object Identifier '" + expr->getText() + "' is not an object");
+					error_handle((--args[1].getTokenIt())->getLocation(), "TODO7: replace unknown with object Identifier '" + expr->getText() + "' is not an object");
 				}
 			}
 
@@ -1765,7 +1768,7 @@ void ParserDriver::defineGrammar()
 				else
 				{
 					// TODO:
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO: replace the unknown symbol with function symbol. You need to set it unknown return type. Make sure that anywhere we check this type we do not mind if it is unknown (only in Incomplete mode)");
+					error_handle((--args[1].getTokenIt())->getLocation(), "TODO8: replace the unknown symbol with function symbol. You need to set it unknown return type. Make sure that anywhere we check this type we do not mind if it is unknown (only in Incomplete mode)");
 				}
 			}
 
@@ -1797,7 +1800,7 @@ void ParserDriver::defineGrammar()
 				else
 				{
 					// TODO: Do sth to allow creation of the output
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO: Do sth to allow creation of the output.");
+					error_handle((--args[1].getTokenIt())->getLocation(), "TODO9: Do sth to allow creation of the output.");
 				}
 			}
 

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1134,8 +1134,6 @@ void ParserDriver::defineGrammar()
 						error_handle((++args[5].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an dictionary");
 					else
 					{
-						// TODO: check that parentSymbol is Undefined and replace it with DictionarySymbol.
-						// error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an dictionary. TODO12: Check that parentSymbol is UnknownSymbol and replace it with dictionary.");
 						auto parentExpr = std::static_pointer_cast<IdExpression>(iterable);
 						const auto& parentTokenText = parentExpr->getSymbolToken()->getText();
 						parentExpr->setSymbol(std::make_shared<DictionarySymbol>(parentTokenText, ExpressionType::Undefined));
@@ -1634,10 +1632,7 @@ void ParserDriver::defineGrammar()
 				if (!incompleteMode())
 					error_handle(args[0].getTokenIt()->getLocation(), "Unrecognized identifier '" + args[0].getTokenIt()->getPureText() + "' referenced");
 				else
-				{
-					// TODODONE: add new symbol undefined/unknown
 					symbol = std::make_shared<Symbol>(Symbol::Type::Undefined, symbol_token->getString(), ExpressionType::Undefined);
-				}
 			}
 			symbol_token->setValue(symbol);
 			auto output = std::make_shared<IdExpression>(symbol_token);
@@ -1653,8 +1648,6 @@ void ParserDriver::defineGrammar()
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + expr->getText() + "' is not an object");
 				else
 				{
-					// error_handle(args[1].getTokenIt()->getLocation(), "TODO2 remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
-					//TODODONE: replace the undefined symbol with structure and the expression must be Object
 					auto parentExpr = std::static_pointer_cast<IdExpression>(expr);
 					const auto& parentTokenText = parentExpr->getSymbolToken()->getText();
 					parentExpr->setSymbol(std::make_shared<StructureSymbol>(parentTokenText));
@@ -1666,14 +1659,8 @@ void ParserDriver::defineGrammar()
 				parentSymbol = std::static_pointer_cast<ReferenceSymbol>(parentSymbol)->getSymbol();
 			if (!parentSymbol->isStructure())
 			{
-				if (!incompleteMode() || !expr->isUndefined())
-					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not a structure");
-				else
-				{
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO3 remove this exception '" + parentSymbol->getName()  + "' referenced. Create new structure symbol and replace the unknown symbol.");
-					//TODO: replace the undefined/unknown symbol with structure
-
-				}
+				assert(!incompleteMode() || !expr->isUndefined());
+				error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not a structure");
 			}
 			auto structParentSymbol = std::static_pointer_cast<StructureSymbol>(parentSymbol);
 
@@ -1685,8 +1672,6 @@ void ParserDriver::defineGrammar()
 					error_handle(args[2].getTokenIt()->getLocation(), "Unrecognized identifier '" + symbol_token->getString() + "' referenced");
 				else
 				{
-					// error_handle(args[2].getTokenIt()->getLocation(), "TODO4 remove this exception '" + symbol_token->getString() + "' referenced");
-					//TODODONE: add new symbol with flag undefined as the attribute?
 					bool inserted = structParentSymbol->addAttribute(std::make_shared<Symbol>(Symbol::Type::Undefined, symbol_token->getString(), ExpressionType::Undefined));
 					attr = structParentSymbol->getAttribute(symbol_token->getString());
 					assert(inserted && attr);
@@ -1708,11 +1693,7 @@ void ParserDriver::defineGrammar()
 				if (!incompleteMode() || !expr->isUndefined())
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + expr->getText() + "' is not an object");
 				else
-				{
-					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO5 remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
-					// TODODONE: replace the undefined/unknown symbol with object
 					expr->setType(ExpressionType::Object);
-				}
 			}
 			std::shared_ptr<Symbol> parentSymbol = std::static_pointer_cast<const IdExpression>(expr)->getSymbol();
 			assert(parentSymbol);
@@ -1726,11 +1707,7 @@ void ParserDriver::defineGrammar()
 				if (!incompleteMode() || !parentSymbol->isUndefined())
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbolName + "' is not an array nor dictionary");
 				else
-				{
-					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO6 remove this exception '" + parentSymbolName + "' referenced. Create new object symbol and replace the unknown symbol.");
 					parentSymbol = std::make_shared<ArraySymbol>(parentSymbolName, ExpressionType::Undefined);
-					//TODO10: What if we are dealing with structured symbol?
-				}
 			}
 
 			std::shared_ptr<const IterableSymbol> iterParentSymbol = std::static_pointer_cast<const IterableSymbol>(parentSymbol);
@@ -1753,10 +1730,7 @@ void ParserDriver::defineGrammar()
 				if (!incompleteMode() || !expr->isUndefined())
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + expr->getText() + "' is not an object");
 				else
-				{
-					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO7: replace unknown with object Identifier '" + expr->getText() + "' is not an object");
 					expr->setType(ExpressionType::Object);
-				}
 			}
 			auto parentExpr = std::static_pointer_cast<IdExpression>(expr);
 			auto parentSymbol = parentExpr->getSymbol();
@@ -1772,7 +1746,6 @@ void ParserDriver::defineGrammar()
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not a function");
 				else
 				{
-					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO8: replace the unknown symbol with function symbol. You need to set it unknown return type. Make sure that anywhere we check this type we do not mind if it is unknown (only in Incomplete mode)");
 					const auto& parentTokenText = parentExpr->getSymbolToken()->getText();
 					std::vector<ExpressionType> type{ExpressionType::Undefined};
 					std::for_each(arguments.begin(), arguments.end(),
@@ -1904,7 +1877,6 @@ void ParserDriver::defineGrammar()
 	_parser.rule("string_enumeration") // vector<Expression::Ptr>
 		.production("STRING_ID", [&](auto&& args) -> Value {
 			TokenIt id = args[0].getTokenIt();
-			// TODO: Consider impacts of allowing undefined strings in Incomplete mode.
 			if (!stringExists(id->getPureText()))
 				error_handle(id->getLocation(), "Reference to undefined string '" + id->getPureText() + "'");
 			if (id->getString().size() > 1)

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1654,25 +1654,25 @@ void ParserDriver::defineGrammar()
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + expr->getText() + "' is not an object");
 				else
 				{
-					error_handle(args[1].getTokenIt()->getLocation(), "TODO remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
+					error_handle(args[1].getTokenIt()->getLocation(), "TODO2 remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
 					//TODO: replace the undefined/unknown symbol with object
 				}
 			}
 
-			auto parentSymbol = std::static_pointer_cast<const IdExpression>(expr)->getSymbol();
+			auto parentSymbol = std::static_pointer_cast<IdExpression>(expr)->getSymbol();
 			while (parentSymbol->isReference())
-				parentSymbol = std::static_pointer_cast<const ReferenceSymbol>(parentSymbol)->getSymbol();
+				parentSymbol = std::static_pointer_cast<ReferenceSymbol>(parentSymbol)->getSymbol();
 			if (!parentSymbol->isStructure())
 			{
 				if (!incompleteMode() || !expr->isUndefined())
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not a structure");
 				else
 				{
-					error_handle((--args[1].getTokenIt())->getLocation(), "TODO remove this exception '" + parentSymbol->getName()  + "' referenced. Create new structure symbol and replace the unknown symbol.");
+					error_handle((--args[1].getTokenIt())->getLocation(), "TODO3 remove this exception '" + parentSymbol->getName()  + "' referenced. Create new structure symbol and replace the unknown symbol.");
 					//TODO: replace the undefined/unknown symbol with structure
 				}
 			}
-			auto structParentSymbol = std::static_pointer_cast<const StructureSymbol>(parentSymbol);
+			auto structParentSymbol = std::static_pointer_cast<StructureSymbol>(parentSymbol);
 
 			TokenIt symbol_token = args[2].getTokenIt();
 			auto attr = structParentSymbol->getAttribute(symbol_token->getString());
@@ -1682,8 +1682,11 @@ void ParserDriver::defineGrammar()
 					error_handle(args[2].getTokenIt()->getLocation(), "Unrecognized identifier '" + symbol_token->getString() + "' referenced");
 				else
 				{
-					error_handle(args[2].getTokenIt()->getLocation(), "TODO remove this exception '" + symbol_token->getString() + "' referenced");
-					//TODO: add new symbol with flag undefined as the attribute?
+					// error_handle(args[2].getTokenIt()->getLocation(), "TODO4 remove this exception '" + symbol_token->getString() + "' referenced");
+					//TODODONE: add new symbol with flag undefined as the attribute?
+					bool inserted = structParentSymbol->addAttribute(std::make_shared<Symbol>(Symbol::Type::Undefined, symbol_token->getString(), ExpressionType::Undefined));
+					attr = structParentSymbol->getAttribute(symbol_token->getString());
+					assert(inserted && attr);
 				}
 			}
 

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -435,8 +435,7 @@ void ParserDriver::defineGrammar()
 			{
 				if (!incompleteMode())
 					error_handle(import->getLocation(), "Unrecognized module '" + import->getString() + "' imported");
-				else
-					error_handle(import->getLocation(), "TODO: remove this");
+				// 	error_handle(import->getLocation(), "TODODONE: remove problem with unrecognized module");
 			}
 			return {};
 		})

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1008,10 +1008,7 @@ void ParserDriver::defineGrammar()
 			TokenIt id = args[0].getTokenIt();
 			assert(id->isString());
 			if (!stringExists(id->getString()))
-			{
-				// TODO: Consider if we need to allow unknown strings in Incomplete mode.
 				error_handle(id->getLocation(), "Reference to undefined string '" + id->getString() + "'");
-			}
 			if (id->getString().size() > 1)
 				id->setValue(findStringDefinition(id->getString()));
 			auto output = std::make_shared<StringExpression>(std::move(id));

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1085,7 +1085,7 @@ void ParserDriver::defineGrammar()
 					else
 					{
 						// TODO: check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.
-						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array. TODO: Check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.");
+						error_handle((++args[3].getTokenIt())->getLocation(), "Identifier '" + parentSymbol->getName() + "' is not an array. TODO11: Check that parentSymbol is UnknownSymbol and replace it with ArraySymbol.");
 					}
 				}
 
@@ -1654,8 +1654,11 @@ void ParserDriver::defineGrammar()
 					error_handle((--args[1].getTokenIt())->getLocation(), "Identifier '" + expr->getText() + "' is not an object");
 				else
 				{
-					error_handle(args[1].getTokenIt()->getLocation(), "TODO2 remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
-					//TODO: replace the undefined/unknown symbol with object
+					// error_handle(args[1].getTokenIt()->getLocation(), "TODO2 remove this exception '" + args[1].getTokenIt()->getPureText() + "' referenced. Create new object symbol and replace the unknown symbol.");
+					//TODODONE: replace the undefined symbol with structure and the expression must be Object
+					auto parentExpr = std::static_pointer_cast<IdExpression>(expr);
+					const auto& parentTokenText = parentExpr->getSymbolToken()->getText();
+					parentExpr->setSymbol(std::make_shared<StructureSymbol>(parentTokenText));
 				}
 			}
 
@@ -1726,7 +1729,7 @@ void ParserDriver::defineGrammar()
 				{
 					// error_handle((--args[1].getTokenIt())->getLocation(), "TODO6 remove this exception '" + parentSymbolName + "' referenced. Create new object symbol and replace the unknown symbol.");
 					parentSymbol = std::make_shared<ArraySymbol>(parentSymbolName, ExpressionType::Undefined);
-					//TODO: What if we are dealing with structured symbol?
+					//TODO10: What if we are dealing with structured symbol?
 				}
 			}
 

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -63,7 +63,8 @@ void addEnums(py::module& module)
 {
 	py::enum_<ParserMode>(module, "ParserMode")
 		.value("Regular", ParserMode::Regular)
-		.value("IncludeGuarded", ParserMode::IncludeGuarded);
+		.value("IncludeGuarded", ParserMode::IncludeGuarded)
+		.value("Incomplete", ParserMode::Incomplete);
 
 	py::enum_<Features>(module, "Features", py::arithmetic())
 		.value("Basic", Features::Basic)

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5350,7 +5350,18 @@ R"(rule abc
 );
 	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
 	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+
+	std::string expected =
+R"(rule abc
+{
+	condition:
+		for all k, v in unknown : (
+			k == "foo" and
+			v == "bar"
+		)
+}
+)";
+	ASSERT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
 
 TEST_F(ParserTests,
@@ -5367,7 +5378,20 @@ rule abc
 );
 	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
 	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+
+	std::string expected =
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		for all k, v in cuckoo.unknown : (
+			k == "foo" and
+			v == "bar"
+		)
+}
+)";
+	ASSERT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
 
 TEST_F(ParserTests,
@@ -5384,7 +5408,20 @@ rule abc
 );
 	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
 	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+
+	std::string expected =
+R"(import "dummy"
+
+rule abc
+{
+	condition:
+		for all k, v in dummy.unknown : (
+			k == "foo" and
+			v == "bar"
+		)
+}
+)";
+	ASSERT_EQ(expected, driver.getParsedFile().getTextFormatted());
 }
 
 TEST_F(ParserTests,

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5205,6 +5205,53 @@ rule rule_3
 }
 
 TEST_F(ParserTests,
+IncompleteRulesReferenceUnknownSymbol) {
+	prepareInput(
+R"(
+rule abc
+{
+	condition:
+		unknown_rule
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+IncompleteRulesIncompleteRule) {
+	prepareInput(
+R"(
+rule abc
+{
+	condition:
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(0u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+IncompleteRulesUnknownImport) {
+	prepareInput(
+R"(
+import "dummy"
+
+rule abc
+{
+	condition:
+		true
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 AutoformattingClosingBracket) {
 	prepareInput(
 R"(

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5205,7 +5205,7 @@ rule rule_3
 }
 
 TEST_F(ParserTests,
-IncompleteRulesReferenceUnknownSymbol) {
+ParseIncompleteReferenceUnknownSymbol) {
 	prepareInput(
 R"(
 rule abc
@@ -5221,7 +5221,7 @@ rule abc
 }
 
 TEST_F(ParserTests,
-IncompleteRulesIncompleteRule) {
+ParseIncompleteRuleNotFinished) {
 	prepareInput(
 R"(
 rule abc
@@ -5235,7 +5235,7 @@ rule abc
 }
 
 TEST_F(ParserTests,
-IncompleteRulesUnknownImport) {
+ParseIncompleteUnknownImport) {
 	prepareInput(
 R"(
 import "dummy"

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5211,7 +5211,224 @@ R"(
 rule abc
 {
 	condition:
-		unknown_rule
+		unknown_symbol
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownArraySymbol) {
+	prepareInput(
+R"(import "pe"
+
+rule abc
+{
+	condition:
+		unknown_array_one[0] and
+		pe.unknown_array_two[10]
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownArraySymbolFromKnownModule) {
+	prepareInput(
+R"(import "pe"
+
+rule abc
+{
+	condition:
+		unknown_array_one[0] and
+		pe.unknown_array_two[10]
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownArraySymbolFromUnknownModule) {
+	prepareInput(
+R"(import "dummy"
+
+rule abc
+{
+	condition:
+		dummy.unknown_array[10]
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownObjectSymbol) {
+	prepareInput(
+R"(rule abc
+{
+	condition:
+		unknown_object.some_element
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownObjectSymbolFromKnownModule) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		cuckoo.unknown_object.some_element
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownObjectSymbolFromUnknownModule) {
+	prepareInput(
+R"(import "dummy"
+
+rule abc
+{
+	condition:
+		dummy.unknown_object.some_element
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownForDict) {
+	prepareInput(
+R"(rule abc
+{
+	condition:
+		for all k, v in unknown : (  k == "foo" and v == "bar" )
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownForDictFromKnownModule) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		for all k, v in cuckoo.unknown : (  k == "foo" and v == "bar" )
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownForDictFromUnknownModule) {
+	prepareInput(
+R"(import "dummy"
+
+rule abc
+{
+	condition:
+		for all k, v in dummy.unknown : (  k == "foo" and v == "bar" )
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownFunctionCall) {
+	prepareInput(
+R"(rule abc
+{
+	condition:
+		unknown("param")
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownFunctionCallFromKnownModule) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		cuckoo.unknown("param")
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownFunctionCallFromUnknownModule) {
+	prepareInput(
+R"(import "dummy"
+
+rule abc
+{
+	condition:
+		dummy.unknown("param")
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownFunctionOverloadOfKnownFunction) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		cuckoo.network.http_request(42)
 }
 )"
 );

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5425,6 +5425,53 @@ rule abc
 }
 
 TEST_F(ParserTests,
+ParseIncompleteUnknownFor) {
+	prepareInput(
+R"(rule abc
+{
+	condition:
+		for all i in unknown : ( i == "foo" )
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownForFromKnownModule) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		for all i in cuckoo.unknown : ( i == "foo" )
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownForFromUnknownModule) {
+	prepareInput(
+R"(rule abc
+{
+	condition:
+		for all i in unknown : ( i == "foo" )
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 ParseIncompleteUnknownFunctionCall) {
 	prepareInput(
 R"(rule abc

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5501,7 +5501,8 @@ rule abc
 );
 	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
 	ASSERT_EQ(0u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+	std::vector<std::string> expected{"\n", "rule", "abc", "\n", "{", "\n", "condition", ":", "\n" };
+	ASSERT_EQ(expected, driver.getParsedFile().getTokenStream()->getTokensAsText());
 }
 
 TEST_F(ParserTests,

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5239,6 +5239,38 @@ rule abc
 }
 
 TEST_F(ParserTests,
+ParseIncompleteUnknownObjectSymbol) {
+	prepareInput(
+R"(rule abc
+{
+	condition:
+		unknown_object.some_element
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ParseIncompleteUnknownObjectSymbolFromKnownModule) {
+	prepareInput(
+R"(import "cuckoo"
+
+rule abc
+{
+	condition:
+		cuckoo.unknown_object.some_element
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 ParseIncompleteUnknownArraySymbol) {
 	prepareInput(
 R"(import "pe"
@@ -5281,38 +5313,6 @@ rule abc
 {
 	condition:
 		dummy.unknown_array[10]
-}
-)"
-);
-	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
-	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
-}
-
-TEST_F(ParserTests,
-ParseIncompleteUnknownObjectSymbol) {
-	prepareInput(
-R"(rule abc
-{
-	condition:
-		unknown_object.some_element
-}
-)"
-);
-	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
-	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
-}
-
-TEST_F(ParserTests,
-ParseIncompleteUnknownObjectSymbolFromKnownModule) {
-	prepareInput(
-R"(import "cuckoo"
-
-rule abc
-{
-	condition:
-		cuckoo.unknown_object.some_element
 }
 )"
 );

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5205,6 +5205,24 @@ rule rule_3
 }
 
 TEST_F(ParserTests,
+ParseIncompleteUnknownImport) {
+	prepareInput(
+R"(
+import "dummy"
+
+rule abc
+{
+	condition:
+		true
+}
+)"
+);
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 ParseIncompleteReferenceUnknownSymbol) {
 	prepareInput(
 R"(
@@ -5228,8 +5246,7 @@ R"(import "pe"
 rule abc
 {
 	condition:
-		unknown_array_one[0] and
-		pe.unknown_array_two[10]
+		unknown_array_one[0]
 }
 )"
 );
@@ -5246,7 +5263,6 @@ R"(import "pe"
 rule abc
 {
 	condition:
-		unknown_array_one[0] and
 		pe.unknown_array_two[10]
 }
 )"
@@ -5448,23 +5464,6 @@ rule abc
 );
 	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
 	ASSERT_EQ(0u, driver.getParsedFile().getRules().size());
-	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
-}
-
-TEST_F(ParserTests,
-ParseIncompleteUnknownImport) {
-	prepareInput(
-R"(
-import "dummy"
-
-rule abc
-{
-	condition:
-		true
-)"
-);
-	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
-	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
 	ASSERT_EQ(input_text, driver.getParsedFile().getTextFormatted());
 }
 

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -1848,26 +1848,25 @@ rule rule1 : Tag1 {
 ''')
         rule = yara_file.rules[0]
 
-        self.assertEqual('''include "nonexistent.yar"
-
-rule rule1 : Tag1 {
-    strings:
-        $1 = "Hello World!"
-        $2 = { 01 23 45 67 89 AB CD EF }
-        $3 = /def/is
-    condition:
-        false
+        self.assertEqual('''rule rule1 : Tag1 {
+	strings:
+		$1 = "Hello World!"
+		$2 = { 01 23 45 67 89 AB CD EF }
+		$3 = /def/is
+	condition:
+		false
 }''', yara_file.text)
 
         expected = r'''include "nonexistent.yar"
 
-rule rule1 : Tag1 {
-    strings:
-        $1 = "Hello World!"
-        $2 = { 01 23 45 67 89 AB CD EF }
-        $3 = /def/is
-    condition:
-        false
+rule rule1 : Tag1
+{
+	strings:
+		$1 = "Hello World!"
+		$2 = { 01 23 45 67 89 AB CD EF }
+		$3 = /def/is
+	condition:
+		false
 }
 '''
         self.assertEqual(expected, yara_file.text_formatted)

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -1833,3 +1833,41 @@ rule rule1
 }
 '''
         self.assertEqual(expected, yara_file.text_formatted)
+
+    def test_include_undefined_file_in_incomplete_mode(self):
+        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Incomplete, str=r'''include "nonexistent.yar"
+
+rule rule1 : Tag1 {
+    strings:
+        $1 = "Hello World!"
+        $2 = { 01 23 45 67 89 AB CD EF }
+        $3 = /def/is
+    condition:
+        false
+}
+''')
+        rule = yara_file.rules[0]
+
+        self.assertEqual('''include "nonexistent.yar"
+
+rule rule1 : Tag1 {
+    strings:
+        $1 = "Hello World!"
+        $2 = { 01 23 45 67 89 AB CD EF }
+        $3 = /def/is
+    condition:
+        false
+}''', yara_file.text)
+
+        expected = r'''include "nonexistent.yar"
+
+rule rule1 : Tag1 {
+    strings:
+        $1 = "Hello World!"
+        $2 = { 01 23 45 67 89 AB CD EF }
+        $3 = /def/is
+    condition:
+        false
+}
+'''
+        self.assertEqual(expected, yara_file.text_formatted)


### PR DESCRIPTION
This PR solves issue [#45](https://github.com/avast/yaramod/issues/45) and allows parsing of:

-  incomplete rules (we can get TokenStream after parsing)
-  rules containing unknown identifiers (we can get text, text_formatted and condition)
-  YARA files importing non-existent files (we can get text, text_formatted and condition)