### PR TITLE
Fix pe.rich_signature types

### DIFF
--- a/modules/module_pe.json
+++ b/modules/module_pe.json
@@ -1068,13 +1068,13 @@
                     "kind": "value",
                     "name": "raw_data",
                     "documentation": "Raw data as it appears in the file.",
-                    "type": "i"
+                    "type": "s"
                 },
                 {
                     "kind": "value",
                     "name": "clear_data",
                     "documentation": "Data after being decrypted by XORing it with the key.",
-                    "type": "i"
+                    "type": "s"
                 },
                 {
                     "kind": "function",


### PR DESCRIPTION
`pe.rich_signature.raw_data` and `pe.rich_signature.clear_data` are set incorrectly to integer type, which causes parser to fail on valid rules like this:

```
import "pe"
import "hash"

rule test {
    condition:
        hash.md5(pe.rich_signature.clear_data) == "d41d8cd98f00b204e9800998ecf8427e"
}
```
It fails with `No matching overload of function 'md5' for these types of parameters: Unexpected argument types for function md5 ( int )`

Issue was introduced in commit 0d07529.