### PR TITLE
Fix YaraFileBuilder recheck with custom modules

### DIFF
--- a/include/yaramod/builder/yara_file_builder.h
+++ b/include/yaramod/builder/yara_file_builder.h
@@ -39,7 +39,7 @@ public:
 	/// @{
 	YaraFileBuilder(Features features = Features::AllCurrent, const std::string& modulesDirectory = "")
 		: _tokenStream(std::make_shared<TokenStream>())
-		, _module_pool(features, modulesDirectory)
+		, _module_pool(std::make_shared<ModulePool>(features, modulesDirectory))
 		, _features(features)
 	{
 	}
@@ -65,7 +65,7 @@ private:
 	std::shared_ptr<TokenStream> _tokenStream; ///< Tokens storage
 	std::map<std::string, TokenIt> _module_tokens; ///< Modules
 	TokenIt _newline_after_imports; ///< Always stands behind newline after last import in the TokenStream
-	ModulePool _module_pool; ///< Storage of used modules
+	std::shared_ptr<ModulePool> _module_pool; ///< Storage of used modules
 	Features _features; ///< Determines which modules should be possible to load
 	std::vector<std::shared_ptr<Rule>> _rules; ///< Rules
 };

--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -80,6 +80,7 @@ public:
 	/// @name Constructors
 	/// @{
 	ParserDriver(Features features = Features::AllCurrent, const std::string& moduleDirectory = "");
+	ParserDriver(Features features, const std::shared_ptr<ModulePool>& modulePool);
 	/// @}
 
 	/// @name Destructor
@@ -205,7 +206,7 @@ private:
 	ParserMode _mode; ///< Parser mode.
 
 	Features _features; ///< Used to determine whether to include Avast-specific or VirusTotal-specific symbols or to skip them
-	ModulePool _modules; ///< Storage of all modules used by this ParserDriver
+	std::shared_ptr<ModulePool> _modules; ///< Storage of all modules used by this ParserDriver
 
 	std::vector<FileContext> _fileContexts;
 	std::vector<TokenIt> _comments; ///< Tokens of parsed comments

--- a/src/builder/yara_file_builder.cpp
+++ b/src/builder/yara_file_builder.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<YaraFile> YaraFileBuilder::get(bool recheck, ParserDriver* exter
 {
 	auto yaraFile = std::make_unique<YaraFile>(std::move(_tokenStream), _features);
 	for (const auto& module_token : _module_tokens)
-		yaraFile->addImport(module_token.second, _module_pool);
+		yaraFile->addImport(module_token.second, *_module_pool);
 	yaraFile->addRules(_rules);
 
 	_module_tokens.clear();
@@ -52,7 +52,7 @@ std::unique_ptr<YaraFile> YaraFileBuilder::get(bool recheck, ParserDriver* exter
 		}
 		else
 		{
-			ParserDriver driver(Features::AllCurrent);
+			ParserDriver driver(Features::AllCurrent, _module_pool);
 			try
 			{
 				driver.parse(ss);


### PR DESCRIPTION
This PR fixes a problem of `YaraFileBuilder::get` method, which when given `recheck=True` did not use any custom provided modules in the `YaraFileBuilder::_module_pool` attribute of the particular `YaraFileBuilder` instance.

- [x] Add failing test reproducing the problem
- [x] Fix the problem