### PR TITLE
Hotfix for user-defined arrays to be handled correctly by autoformatter

### DIFF
--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1833,7 +1833,7 @@ void ParserDriver::defineGrammar()
 				TokenIt lsqb = args[0].getTokenIt();
 				lsqb->setType(TokenType::LSQB_ENUMERATION);
 				TokenIt rsqb = args[2].getTokenIt();
-				lsqb->setType(TokenType::RSQB_ENUMERATION);
+				rsqb->setType(TokenType::RSQB_ENUMERATION);
 				auto output = std::make_shared<IterableExpression>(lsqb, std::move(args[1].getMultipleExpressions()), rsqb);
 				output->setTokenStream(currentTokenStream());
 				return output;

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -766,10 +766,6 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 			inside_enumeration_brackets = true;
 		else if (current == TokenType::RP_ENUMERATION)
 			inside_enumeration_brackets = false;
-		else if (current == TokenType::LSQB_ENUMERATION)
-			inside_enumeration_brackets = true;
-		else if (current == TokenType::RSQB_ENUMERATION)
-			inside_enumeration_brackets = false;
 		else if (it->isStringModifier())
 			inside_string_modifiers = true;
 

--- a/tests/cpp/visitor_tests.cpp
+++ b/tests/cpp/visitor_tests.cpp
@@ -839,7 +839,7 @@ rule rule_name
 	condition:
 		(
 			true and
-			all of [var > 5.5, time.now() > 500]
+			all of [ var > 5.5, time.now() > 500 ]
 		) or
 		false
 }


### PR DESCRIPTION
It's still not ideal because for example for rule

```yara
	condition:
		1 of [
			cuckoo.sync.mutex(/a/),
			cuckoo.sync.mutex(/b/)
		]
```

is formatted into

```yara
	condition:
		1 of [
		cuckoo.sync.mutex(/a/),
		cuckoo.sync.mutex(/b/)
		]
}
```

but at least it no longer crashes. Once it's merged please release 3.9.2 as a hotfix release.