### PR TITLE
Make multiline custom arrays indent proper

### DIFF
--- a/include/yaramod/types/token.h
+++ b/include/yaramod/types/token.h
@@ -94,7 +94,8 @@ public:
 			|| _type == TokenType::REGEXP_START_SLASH
 			|| _type == TokenType::HEX_START_BRACKET
 			|| _type == TokenType::LP_WITH_SPACE_AFTER
-			|| _type == TokenType::LP_WITH_SPACES;
+			|| _type == TokenType::LP_WITH_SPACES
+			|| _type == TokenType::LSQB_ENUMERATION;
 	}
 
 	bool isRightBracket() const
@@ -105,7 +106,8 @@ public:
 			|| _type == TokenType::REGEXP_END_SLASH
 			|| _type == TokenType::HEX_END_BRACKET
 			|| _type == TokenType::RP_WITH_SPACE_BEFORE
-			|| _type == TokenType::RP_WITH_SPACES;
+			|| _type == TokenType::RP_WITH_SPACES
+			|| _type == TokenType::RSQB_ENUMERATION;
 	}
 
 	bool isStringModifier() const

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -2891,6 +2891,40 @@ rule nested_for_array_condition
 	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
 }
 
+TEST_F(ParserTests,
+UserDefinedArrayWorks) {
+	prepareInput(
+R"(
+import "cuckoo"
+
+rule user_defined_array
+{
+	condition:
+		1 of [cuckoo.sync.mutex(/a/),
+			cuckoo.sync.mutex(/b/)]
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+
+	std::string expected = R"(
+import "cuckoo"
+
+rule user_defined_array
+{
+	condition:
+		1 of [
+			cuckoo.sync.mutex(/a/),
+			cuckoo.sync.mutex(/b/)
+		]
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
 
 TEST_F(ParserTests,
 ForDictConditionWorks) {


### PR DESCRIPTION
Hotfix provided in [#170](https://github.com/avast/yaramod/pull/170) did not cover proper indenting which this PR solves as can be seen in the added test.