### PR TITLE
Interchangeable strings and variables sections

### DIFF
--- a/include/yaramod/parser/value.h
+++ b/include/yaramod/parser/value.h
@@ -14,6 +14,7 @@
 #include "yaramod/types/rule.h"
 #include "yaramod/types/regexp.h"
 #include "yaramod/types/token_stream.h"
+#include "yaramod/types/sections_summary.h"
 
 #pragma once
 
@@ -52,7 +53,8 @@ public:
 		TokenIt,
 		RegexpRangePair, //20
 		RegexpClassRecord,
-		std::vector<Variable> //22
+		std::vector<Variable>, //22
+		std::shared_ptr<SectionsSummary>
 	>;
 
 	/// @name Constructors
@@ -110,6 +112,11 @@ public:
 	std::shared_ptr<Rule::StringsTrie>&& getStringsTrie()
 	{
 		return std::move(moveValue<std::shared_ptr<Rule::StringsTrie>>());
+	}
+
+	std::shared_ptr<SectionsSummary>&& getSectionsSummary()
+	{
+		return std::move(moveValue<std::shared_ptr<SectionsSummary>>());
 	}
 
 	std::shared_ptr<StringModifier>&& getStringMod()

--- a/include/yaramod/types/rule.h
+++ b/include/yaramod/types/rule.h
@@ -88,6 +88,7 @@ public:
 	void setName(const std::string& name);
 	void setMetas(const std::vector<Meta>& metas);
 	void setVariables(const std::vector<Variable>& variables);
+	void setStringsTrie(const std::shared_ptr<StringsTrie>&& strings);
 	void setTags(const std::vector<std::string>& tags);
 	void setCondition(const Expression::Ptr& condition);
 	void setLocation(const Location& location) { _location = location; }

--- a/include/yaramod/types/sections_summary.h
+++ b/include/yaramod/types/sections_summary.h
@@ -1,0 +1,52 @@
+/**
+ * @file src/types/sections_summary.h
+ * @brief Declaration of class Variable.
+ * @copyright (c) 2021 Avast Software, licensed under the MIT license
+ */
+
+#pragma once
+
+#include "yaramod/types/rule.h"
+#include "yaramod/types/variable.h"
+
+namespace yaramod {
+
+/**
+ * Class representing sections summary
+ * in the YARA rules.
+ */
+class SectionsSummary
+{
+public:
+	/// @name Constructors
+	/// @{
+	SectionsSummary(std::shared_ptr<Rule::StringsTrie> default_strings, std::vector<Variable> default_variables) : _strings(default_strings), _variables(default_variables) {}
+	SectionsSummary(const SectionsSummary& section_summary) = default;
+	SectionsSummary(SectionsSummary&& section_summary) = default;
+	/// @}
+
+	/// @name Assignment
+	/// @{
+	SectionsSummary& operator=(const SectionsSummary&) = default;
+	SectionsSummary& operator=(SectionsSummary&&) = default;
+	/// @}
+
+	/// @name Getter methods
+	/// @{
+	const std::shared_ptr<Rule::StringsTrie> getStringsTrie() const;
+	const std::vector<Variable> getVariables() const;
+	/// @}
+
+
+	/// @name Setter methods
+	/// @{
+	void setStringsTrie(const std::shared_ptr<Rule::StringsTrie> strings);
+	void setVariables(const std::vector<Variable> variables);
+	/// @}
+
+private:
+	std::shared_ptr<Rule::StringsTrie> _strings; ///< Strings
+	std::vector<Variable> _variables; ///< Variables 
+};
+
+}

--- a/include/yaramod/types/sections_summary.h
+++ b/include/yaramod/types/sections_summary.h
@@ -20,7 +20,8 @@ class SectionsSummary
 public:
 	/// @name Constructors
 	/// @{
-	SectionsSummary(std::shared_ptr<Rule::StringsTrie> default_strings, std::vector<Variable> default_variables) : _strings(default_strings), _variables(default_variables) {}
+	SectionsSummary(std::shared_ptr<Rule::StringsTrie> default_strings, std::vector<Variable> default_variables)
+        : _strings(default_strings), _variables(default_variables), _is_strings_set(false), _is_variables_set(false) {}
 	SectionsSummary(const SectionsSummary& section_summary) = default;
 	SectionsSummary(SectionsSummary&& section_summary) = default;
 	/// @}
@@ -37,6 +38,8 @@ public:
 	const std::vector<Variable> getVariables() const;
 	/// @}
 
+    bool isStringsTrieSet() { return _is_strings_set; }
+    bool isVariablesSet() { return _is_variables_set; }
 
 	/// @name Setter methods
 	/// @{
@@ -45,6 +48,8 @@ public:
 	/// @}
 
 private:
+    bool _is_strings_set;
+    bool _is_variables_set;
 	std::shared_ptr<Rule::StringsTrie> _strings; ///< Strings
 	std::vector<Variable> _variables; ///< Variables 
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
 	types/modules/module_pool.cpp
 	types/plain_string.cpp
 	types/rule.cpp
+	types/sections_summary.cpp
 	types/token.cpp
 	types/token_stream.cpp
 	types/yara_file.cpp

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -499,16 +499,16 @@ void ParserDriver::defineGrammar()
 				"rule_mods", "RULE", common_last_rule, "ID", common_rule_init, "tags", "LCB", "metas", "sections_summary", "condition" , "RCB", [&](auto&& args) -> Value {
 				auto rule = createCommonRule(args);
 				auto sections_summary = std::move(args[8].getSectionsSummary());
-				auto variables = std::move(sections_summary->getVariables());
+				auto variables = sections_summary->getVariables();
 
-				rule.setVariables(std::move(variables));
+				rule.setVariables(variables);
 				rule.setStringsTrie(std::move(sections_summary->getStringsTrie()));
 				rule.setCondition(std::move(args[9].getExpression()));
 				args[10].getTokenIt()->setType(TokenType::RULE_END);
 
-				//for(auto iter = variables.begin(); iter != variables.end(); iter++) {
-				//	removeLocalSymbol(iter->getKey());
-				//}
+				for(auto iter = variables.begin(); iter != variables.end(); iter++) {
+					removeLocalSymbol(iter->getKey());
+				}
 
 				addRule(std::move(rule));
 				return {};

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -469,11 +469,19 @@ void ParserDriver::defineGrammar()
 		_parser.rule("sections_summary") // std::shared_ptr<SectionsSummary>
 				.production("sections_summary", "variables", [&](auto&& args) -> Value {
 					auto section_summary = std::move(args[0].getSectionsSummary());
+					if (section_summary->isVariablesSet())
+					{
+						error_handle(currentFileContext()->getLocation(), "Duplicate variables section.");
+					}
 					section_summary->setVariables(args[1].getVariables());
 					return section_summary;
 				})
 				.production("sections_summary", "strings", [&](auto&& args) -> Value {
 					auto section_summary = std::move(args[0].getSectionsSummary());
+					if (section_summary->isStringsTrieSet())
+					{
+						error_handle(currentFileContext()->getLocation(), "Duplicate strings section.");
+					}
 					section_summary->setStringsTrie(std::move(args[1].getStringsTrie()));
 					return section_summary;
 				})

--- a/src/types/rule.cpp
+++ b/src/types/rule.cpp
@@ -326,6 +326,16 @@ void Rule::setVariables(const std::vector<Variable>& variables)
 }
 
 /**
+ * Sets the condition expression of the YARA rule.
+ *
+ * @param condition Condition expression.
+ */
+void Rule::setStringsTrie(const std::shared_ptr<StringsTrie>&& strings)
+{
+	_strings = strings;
+}
+
+/**
  * Sets the tags of the rule.
  *
  * @param tags Tags to set.

--- a/src/types/sections_summary.cpp
+++ b/src/types/sections_summary.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file src/types/sections_summary.cpp
+ * @brief Implementation of class SectionsSummary.
+ * @copyright (c) 2021 Avast Software, licensed under the MIT license
+ */
+
+#include "yaramod/types/sections_summary.h"
+#include "yaramod/types/rule.h"
+#include "yaramod/types/variable.h"
+
+namespace yaramod {
+
+/**
+ * Returns StringsTrie.
+ *
+ * @return StringsTrie.
+ */
+const std::shared_ptr<Rule::StringsTrie> SectionsSummary::getStringsTrie() const
+{
+	return std::move(_strings);
+}
+
+/**
+ * Returns vector of variables.
+ *
+ * @return Vector of variables.
+ */
+const std::vector<Variable> SectionsSummary::getVariables() const
+{
+	return _variables;
+}
+
+/**
+ * Set the StringsTrie.
+ *
+ * @param key Key.
+ */
+void SectionsSummary::setStringsTrie(const std::shared_ptr<Rule::StringsTrie> strings)
+{
+	_strings = std::move(strings);
+}
+
+/**
+ * Set the vector of variables.
+ *
+ * @param value Value.
+ */
+void SectionsSummary::setVariables(const std::vector<Variable> variables)
+{
+	_variables = variables;
+}
+
+}

--- a/src/types/sections_summary.cpp
+++ b/src/types/sections_summary.cpp
@@ -37,6 +37,7 @@ const std::vector<Variable> SectionsSummary::getVariables() const
  */
 void SectionsSummary::setStringsTrie(const std::shared_ptr<Rule::StringsTrie> strings)
 {
+    _is_strings_set = true;
 	_strings = std::move(strings);
 }
 
@@ -47,6 +48,7 @@ void SectionsSummary::setStringsTrie(const std::shared_ptr<Rule::StringsTrie> st
  */
 void SectionsSummary::setVariables(const std::vector<Variable> variables)
 {
+    _is_variables_set = true;
 	_variables = variables;
 }
 

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -1804,6 +1804,36 @@ std::string expected = R"(rule rule1
 }
 
 TEST_F(ParserTests,
+RuleWithUnorderedSections) {
+	prepareInput(
+R"(rule rule1
+{
+	variables:
+		var = 23
+	strings:
+		$1 = "Hello World!"
+	condition:
+		true
+}
+)");
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+std::string expected = R"(rule rule1
+{
+	variables:
+		var = 23
+	strings:
+		$1 = "Hello World!"
+	condition:
+		true
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 GlobalRuleModifierWorks) {
 	prepareInput(
 R"(

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -201,6 +201,31 @@ rule rule_with_variables {
         self.assertTrue(rule.variables[4].value.symbol.is_structure)
         self.assertEqual(rule.variables[4].value.symbol.name, 'time')
 
+    def test_rule_with_unordered_sections(self):
+        yara_file = yaramod.Yaramod(yaramod.Features.Avast).parse_string('''
+rule rule_with_unordered_sections
+{
+	variables:
+		var = 25.8
+	strings:
+		$1 = "Hello World!"
+	condition:
+		true
+}''')
+
+        expected = r'''
+rule rule_with_unordered_sections
+{
+	variables:
+		var = 25.8
+	strings:
+		$1 = "Hello World!"
+	condition:
+		true
+}
+'''
+        self.assertEqual(expected, yara_file.text_formatted)
+
     def test_rule_with_variable_and_string(self):
         yara_file = yaramod.Yaramod(yaramod.Features.Avast).parse_string('''
 import "time"


### PR DESCRIPTION
Up until now, you could only define first strings and then variables. Defining variables and then strings was not supported by the parser, even though YARA supports such rule.

The only supported way of defining strings and variables:
```
rule r {
  strings:
    $1 = "one"
  variables:
    var = 123
  condition:
    true
}
```
Unsupported rule that throws an error:
```
rule r {
  variables:
    var = 123
  strings:
    $1 = "one"
  condition:
    true
}
```

From now on, the parser will successfully parse rules with string and variable sections defined in reverse order as well. The default section order when regenerating such rule back into fulltext representation is going to stay like it used to- first strings and then variables.