### PR TITLE
Separate includes and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Separate includes and imports with blank lines ([#187](https://github.com/avast/yaramod/pull/187), [#130](https://github.com/avast/yaramod/issues/130))
+
 # v3.11.0 (2021-08-30)
 
 * Added additional constants of enums to `pe` module ([#183](https://github.com/avast/yaramod/pull/183))

--- a/docs/rtd/requirements.txt
+++ b/docs/rtd/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx>=2.4.2,<2.5.0
-sphinx_rtd_theme>=0.4.3,<0.5.0
-sphinx-tabs>=1.1.13,<1.2.0
+Sphinx>=4.3.0
+sphinx_rtd_theme>=0.4.3
+sphinx-tabs>=1.1.13

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -1876,8 +1876,9 @@ rule rule_pedia {
 }''', yara_file.text)
 
     def test_include_undefined_file_in_incomplete_mode(self):
-        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Incomplete, str=r'''include "nonexistent.yar"
-
+        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Incomplete, str=r'''include "nonexistent1.yar"
+include "nonexistent2.yar" include "nonexistent3.yar" /* comment 1 */ include "nonexistent4.yar" // comment 2
+include "nonexistent5.yar" // comment 3
 rule rule1 : Tag1 {
     strings:
         $1 = "Hello World!"
@@ -1898,7 +1899,11 @@ rule rule1 : Tag1 {
 		false
 }''', yara_file.text)
 
-        expected = r'''include "nonexistent.yar"
+        expected = r'''include "nonexistent1.yar"
+include "nonexistent2.yar"
+include "nonexistent3.yar" /* comment 1 */
+include "nonexistent4.yar" // comment 2
+include "nonexistent5.yar" // comment 3
 
 rule rule1 : Tag1
 {

--- a/tests/python/testing_rules/testing_file_with_import.yar
+++ b/tests/python/testing_rules/testing_file_with_import.yar
@@ -1,0 +1,8 @@
+include "testing_include.yar"
+import "cuckoo"
+
+rule rule1
+{
+	condition:
+		RULE and true
+}


### PR DESCRIPTION
Solving #130 so that includes and imports are separated by newlines respectfully to any comments between.
Also Sphinx used in documentation build needed to be updated.