### PR TITLE
Trim whitespaces of oneline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Strip trailing whitespace off oneline comments ([#149](https://github.com/avast/yaramod/issues/149), [#189](https://github.com/avast/yaramod/pull/189))
 * Fix adding meta to add it after comment of last present meta if present ([#102](https://github.com/avast/yaramod/issues/102), [#188](https://github.com/avast/yaramod/pull/188))
 * Separate includes and imports with blank lines ([#187](https://github.com/avast/yaramod/pull/187), [#130](https://github.com/avast/yaramod/issues/130))
 

--- a/include/yaramod/types/literal.h
+++ b/include/yaramod/types/literal.h
@@ -14,8 +14,8 @@
 #include <sstream>
 #include <variant>
 
-#include "yaramod/yaramod_error.h"
 #include "yaramod/types/symbol.h"
+#include "yaramod/yaramod_error.h"
 
 namespace yaramod {
 

--- a/include/yaramod/types/literal.h
+++ b/include/yaramod/types/literal.h
@@ -93,6 +93,7 @@ public:
 	/// @name String representation
 	/// @{
 	void markEscaped() {  _escaped = true; }
+	bool trimWhitespaces();
 	std::string getText(bool pure = false) const;
 	std::string getPureText() const;
 	/// @}

--- a/include/yaramod/types/token.h
+++ b/include/yaramod/types/token.h
@@ -35,6 +35,8 @@ public:
 		, _location()
 		, _wanted_column(0)
 	{
+		if (_type == TokenType::ONELINE_COMMENT)
+			_value->trimWhitespaces();
 	}
 
 	Token(TokenType type, Literal&& value)
@@ -43,6 +45,8 @@ public:
 		, _location()
 		, _wanted_column(0)
 	{
+		if (_type == TokenType::ONELINE_COMMENT)
+			_value->trimWhitespaces();
 	}
 
 	Token(const Token& other) = default;

--- a/include/yaramod/utils/utils.h
+++ b/include/yaramod/utils/utils.h
@@ -20,7 +20,7 @@ std::string unescapeString(std::string_view str);
 bool endsWith(const std::string& str, const std::string& withWhat);
 bool endsWith(const std::string& str, char withWhat);
 
-std::string trim(std::string str);
+std::string trim(std::string str, const std::string& toTrim = " \n\r\t\v");
 
 /**
  * Checks whether string starts with another string or character.

--- a/src/types/literal.cpp
+++ b/src/types/literal.cpp
@@ -214,6 +214,16 @@ std::string Literal::getFormattedValue() const
 	return _formatted_value.value_or(std::string());
 }
 
+bool Literal::trimWhitespaces()
+{
+	if (isString())
+	{
+		setValue(trim(getString(), " \n\t\v"));
+		return true;
+	}
+	return false;
+}
+
 /**
  * Returns the string representation of the literal in a specified format:
  *

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -189,11 +189,10 @@ bool endsWith(const std::string& str, char withWhat)
 	return !str.empty() && str.back() == withWhat;
 }
 
-std::string trim(std::string str)
+std::string trim(std::string str, const std::string& toTrim)
 {
 	// Based on
 	// http://www.codeproject.com/Articles/10880/A-trim-implementation-for-std-string
-	const std::string toTrim = " \n\r\t\v";
 	std::string::size_type pos = str.find_last_not_of(toTrim);
 	if (pos != std::string::npos)
 	{

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -5100,6 +5100,39 @@ rule nonutf_condition
 }
 
 TEST_F(ParserTests,
+RemoveTrailingWhitespacesFromComments) {
+	prepareInput(
+R"(
+rule trailing_whitespaces_in_comments_rule
+{
+	meta:
+		author = "Mr. Avastien" // comment with extra tab	
+	strings:
+		$s1 = "text" // comment with extra space 
+	condition:
+		$s1
+}
+)");
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	std::string expected =
+R"(
+rule trailing_whitespaces_in_comments_rule
+{
+	meta:
+		author = "Mr. Avastien" // comment with extra tab
+	strings:
+		$s1 = "text" // comment with extra space
+	condition:
+		$s1
+}
+)";
+
+	EXPECT_EQ(expected, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 AddMetaAfterParse) {
 	prepareInput(
 R"(


### PR DESCRIPTION
Solving #149. Please note the following properties of the solution:

- Only one-line comments are stripped of trailing whitespaces, because when somebody prefers /* comment */ to /*comment*/ I do not intend to make them angry.
- The comments are stripped during their construction, thus only once. I could have made it the other way, so that the comments would be stripped every time we print TokenStream, but we do not need to store the information about where were the whitespaces. Sorry for mentioning this if it is obvious.