### PR TITLE
Make empty strings section invalid

### DIFF
--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -328,6 +328,29 @@ rule variable_in_condition
 }
 
 TEST_F(ParserTests,
+RuleWithNoStringsDoesntWork) {
+	prepareInput(
+R"(
+rule rule_with_no_strings
+{
+	strings:
+	condition:
+		true
+}
+)");
+	try
+	{
+		driver.parse(input);
+		FAIL() << "Parser did not throw an exception.";
+	}
+	catch (const ParserError& err)
+	{
+		EXPECT_EQ(0u, driver.getParsedFile().getRules().size());
+		EXPECT_EQ("Error at 5.2-10: Syntax error: Unexpected condition, expected one of string identifier", err.getErrorMessage());
+	}
+}
+
+TEST_F(ParserTests,
 RuleWithPlainTextStringsWorks) {
 	prepareInput(
 R"(


### PR DESCRIPTION
Another small PR from me. This time I've tackled #141.

After merging this, empty `strings:` section won't be allowed. I achieve this by adding a new rule for `strings_body_nonempty` that cannot be empty, and using it instead of `strings_body` in the main derivation. 

This is not related to any issue with mquery, but saw that issue on the issue list and figured I can try to solve it. I realise it's very low priority, but probably also won't hurt.

fixes: #141