### PR TITLE
YARA-1551: Yara42 pe module attributes

### DIFF
--- a/modules/module_pe.json
+++ b/modules/module_pe.json
@@ -1745,6 +1745,116 @@
                 }
             ]
         },
+		{
+			"kind": "array",
+			"name": "import_details",
+			"documentation": "Array of structures containing information about the PE's imports libraries.",
+			"structure": {
+				"kind": "struct",
+				"name": "import_details",
+				"attributes": [
+					{
+						"kind": "value",
+						"name": "library_name",
+						"documentation": "Library name.",
+						"type": "s"
+					},
+					{
+						"kind": "value",
+						"name": "number_of_functions",
+						"documentation": "Number of imported function.",
+						"type": "i"
+					},
+					{
+						"kind": "array",
+						"name": "functions",
+						"documentation": "Array of structures containing information about the PE's imports functions.",
+						"structure": {
+							"kind": "struct",
+							"name": "functions",
+							"attributes": [
+								{
+									"kind": "value",
+									"name": "name",
+									"documentation": "Name of imported function.",
+									"type": "s"
+								},
+								{
+									"kind": "value",
+									"name": "ordinal",
+									"documentation": " Ordinal of imported function. If ordinal does not exist this value is YR_UNDEFINED.",
+									"type": "i"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"kind": "value",
+			"name": "number_of_imported_functions",
+			"documentation": "Number of imported functions in the PE.",
+			"type": "i"
+		},
+		{
+			"kind": "value",
+			"name": "number_of_delayed_imported_functions",
+			"documentation": "Number of delay imported functions in the PE.",
+			"type": "i"
+		},
+		{
+			"kind": "value",
+			"name": "number_of_delayed_imports",
+			"documentation": "Number of delay imported DLLs in the PE. (Number of IMAGE_DELAYLOAD_DESCRIPTOR parsed from file).",
+			"type": "i"
+		},
+		{
+			"kind": "array",
+			"name": "delayed_import_details",
+			"documentation": "Array of structures containing information about the PE's delay imports libraries.",
+			"structure": {
+				"kind": "struct",
+				"name": "import_details",
+				"attributes": [
+					{
+						"kind": "value",
+						"name": "library_name",
+						"documentation": "Library name.",
+						"type": "s"
+					},
+					{
+						"kind": "value",
+						"name": "number_of_functions",
+						"documentation": "Number of imported function.",
+						"type": "i"
+					},
+					{
+						"kind": "array",
+						"name": "functions",
+						"documentation": "Array of structures containing information about the PE's imports functions.",
+						"structure": {
+							"kind": "struct",
+							"name": "functions",
+							"attributes": [
+								{
+									"kind": "value",
+									"name": "name",
+									"documentation": "Name of imported function.",
+									"type": "s"
+								},
+								{
+									"kind": "value",
+									"name": "ordinal",
+									"documentation": " Ordinal of imported function. If ordinal does not exist this value is YR_UNDEFINED.",
+									"type": "i"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
         {
             "kind": "function",
             "name": "locale",

--- a/modules/module_pe.json
+++ b/modules/module_pe.json
@@ -1760,7 +1760,71 @@
                         }
                     ],
                     "documentation": "Function returning the number of functions from the PE imports where a function name matches function_regexp and a DLL name matches dll_regexp. Both dll_regexp and function_regexp are case sensitive unless you use the \"/i\" modifier in the regexp."
-                }
+                },
+                {
+					"arguments": [
+						{
+							"type": "i",
+							"name": "import_flag"
+						},
+						{
+							"type": "s",
+							"name": "dll_name"
+						},
+						{
+							"type": "s",
+							"name": "function_name"
+						}
+					],
+					"documentation": "Function returning true if the PE imports function_name from dll_name in specified import type, or false otherwise. dll_name is case insensitive."
+				},
+				{
+					"arguments": [
+						{
+							"type": "i",
+							"name": "import_flag"
+						},
+						{
+							"type": "s",
+							"name": "dll_name"
+						},
+						{
+							"type": "i",
+							"name": "ordinal"
+						}
+					],
+					"documentation": "Function returning true if the PE imports ordinal from dll_name in specified import type, or false otherwise. dll_name is case insensitive."
+				},
+				{
+					"arguments": [
+						{
+							"type": "i",
+							"name": "import_flag"
+						},
+						{
+							"type": "s",
+							"name": "dll_name"
+						}
+					],
+					"documentation": "Function returning the number of functions from the dll_name in specified import type, in the PE imports. dll_name is case insensitive."
+				},
+				{
+					"arguments": [
+						{
+							"type": "i",
+							"name": "import_flag"
+						},
+						{
+							"type": "r",
+							"name": "dll_regexp"
+						},
+						{
+							"type": "r",
+							"name": "function_regexp"
+						}
+					],
+					"documentation": "Function returning the number of functions from the PE imports where a function name matches function_regexp and a DLL name matches dll_regexp in specified import type. Both dll_regexp and function_regexp are case sensitive unless you use the \"/i\" modifier in the regexp."
+				}
             ]
         },
 		{

--- a/modules/module_pe.json
+++ b/modules/module_pe.json
@@ -1691,6 +1691,24 @@
             }
         },
         {
+			"kind": "value",
+			"name": "IMPORT_STANDARD",
+			"documentation": "Flag specifying which import should function imports(int,...) search",
+			"type": "i"
+		},
+		{
+			"kind": "value",
+			"name": "IMPORT_DELAYED",
+			"documentation": "Flag specifying which import should function imports(int,...) search",
+			"type": "i"
+		},
+		{
+			"kind": "value",
+			"name": "IMPORT_ANY",
+			"documentation": "Flag specifying which import should function imports(int,...) search",
+			"type": "i"
+		},
+        {
             "kind": "function",
             "name": "imports",
             "return_type": "i",

--- a/modules/module_pe.json
+++ b/modules/module_pe.json
@@ -1070,7 +1070,13 @@
         {
             "kind": "value",
             "name": "entry_point",
-            "documentation": "Entry point raw offset or virtual address depending on whether YARA is scanning a file or process memory respectively. This is equivalent to the deprecated `entrypoint` keyword.",
+            "documentation": "Entry point file offset or virtual address depending on whether YARA is scanning a file or process memory respectively. This is equivalent to the deprecated `entrypoint` keyword.",
+            "type": "i"
+        },
+        {
+            "kind": "value",
+            "name": "entry_point_raw",
+            "documentation": "Entry point raw value from the optional header of the PE. This value is not converted to a file offset or an RVA.",
             "type": "i"
         },
         {

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3617,6 +3617,30 @@ rule pe_module
 }
 
 TEST_F(ParserTests,
+PeModuleWorks3) {
+	prepareInput(
+R"(
+import "pe"
+
+rule pe_module
+{
+	strings:
+		$a = { E8 00 00 00 00 }
+	condition:
+		$a at pe.entry_point_raw
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ(R"($a at pe.entry_point_raw)", rule->getCondition()->getText());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 VirusTotalSymbolsWork) {
 	prepareInput(
 R"(

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -2008,6 +2008,51 @@ rule test_rule
 
         self.assertEqual(expected, yara_file.text_formatted)
 
+    def test_pe_number_of_imported_functions(self):
+        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Regular, str=r'''
+import "pe"
+
+rule pe_number_of_imported_functions {
+	condition:
+		pe.number_of_imported_functions == 1
+	}
+''')
+
+        self.assertEqual(len(yara_file.rules), 1)
+
+
+    def test_pe_delayed_imports(self):
+        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Regular, str=r'''
+import "pe"
+
+rule pe_number_of_imported_functions {
+	condition:
+		pe.number_of_delayed_imports == 1 and
+		pe.number_of_delayed_imported_functions == 1 and
+		pe.delayed_import_details[0].library_name == "LIB.dll" and
+		pe.delayed_import_details[0].functions[0].name == "function" and
+		pe.delayed_import_details[0].functions[0].ordinal != 0
+}
+''')
+
+        self.assertEqual(len(yara_file.rules), 1)
+
+
+    def test_pe_imports(self):
+        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Regular, str=r'''
+import "pe"
+
+rule pe_number_of_imported_functions {
+	condition:
+		pe.imports(pe.IMPORT_DELAYED, "lib", "fun") and
+		pe.imports(pe.IMPORT_ANY, "lib", 0) and
+		pe.imports(pe.IMPORT_STANDARD, "lib") and
+		pe.imports(pe.IMPORT_DELAYED, /lib/, /fun/)
+}
+''')
+
+        self.assertEqual(len(yara_file.rules), 1)
+
     def test_parse_elf_dynsym(self):
         yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Regular, str=r'''import "elf"
 


### PR DESCRIPTION
Additionally to the ticket's instructions, we migrate:
pe.imports and pe.number_of_delayed_imports
We also solve YARA-1747 by adding pe.entry_point_raw