### PR TITLE
Allow strings to have implicit conversion to bool same as YARA

### DIFF
--- a/include/yaramod/builder/yara_expression_builder.h
+++ b/include/yaramod/builder/yara_expression_builder.h
@@ -131,7 +131,7 @@ public:
 
 	/// @name Detection methods
 	/// @{
-	bool canBeBool() const { return _expr->isBool() || _expr->isFloat() || _expr->isInt() || _expr->isUndefined(); }
+	bool canBeBool() const { return _expr->isBool() || _expr->isFloat() || _expr->isInt() || _expr->isString() || _expr->isUndefined(); }
 	/// @}
 
 	/// @name Builder method

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -2140,5 +2140,35 @@ rule of_rule_builder
 )", yaraFile->getTextFormatted());
 }
 
+TEST_F(BuilderTests,
+StringAsBoolInConditionWorks) {
+	auto cond = (stringVal("abc") && stringVal("def")).get();
+
+	YaraRuleBuilder newRule;
+	auto rule = newRule
+			.withName("rule1")
+			.withCondition(std::move(cond))
+			.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+			.withRule(std::move(rule))
+			.get(true);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(rule rule1 {
+	condition:
+		"abc" and "def"
+})", yaraFile->getText());
+
+	EXPECT_EQ(R"(rule rule1
+{
+	condition:
+		"abc" and
+		"def"
+}
+)", yaraFile->getTextFormatted());
+}
+
 }
 }


### PR DESCRIPTION
When using builder interface, strings couldn't benefit from implicit cast to booleans, since they were excluded from all the types that can be casted to bools.