### PR TITLE
Generate UIDs for AST nodes with Expression base class

### DIFF
--- a/docs/rtd/parsing_rulesets.rst
+++ b/docs/rtd/parsing_rulesets.rst
@@ -302,7 +302,8 @@ Let's say we want to print each function that is in called in the rule condition
 Expression types
 ****************
 
-There are a lot of expression types that you can visit. Here is a list of them all:
+Each expression type has its own unique id (uid). These uids are unique only within scope of a single rule,
+this allows to identify specific node in the AST for extra processing. There are a lot of expression types that you can visit. Here is a list of them all:
 
 **String expressions**
 

--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -19,6 +19,7 @@
 #include <pog/pog.h>
 
 #include "yaramod/parser/file_context.h"
+#include "yaramod/parser/uid_generator.h"
 #include "yaramod/parser/value.h"
 #include "yaramod/types/expressions.h"
 #include "yaramod/types/meta.h"
@@ -203,6 +204,8 @@ private:
 
 	bool _sectionStrings = false; ///< flag used to determine if we parse section after 'strings:'
 	bool _escapedContent = false; ///< flag used to determine if a currently parsed literal contains hexadecimal byte (such byte must be unescaped in getPureText())
+
+	UidGenerator _uidGen;
 
 	ParserMode _mode; ///< Parser mode.
 

--- a/include/yaramod/parser/uid_generator.h
+++ b/include/yaramod/parser/uid_generator.h
@@ -1,0 +1,32 @@
+/**
+ * @file src/parser/uid_generator.h
+ * @brief Declaration of class UidGenerator.
+ * @copyright (c) 2022 Avast Software, licensed under the MIT license
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace yaramod {
+
+/**
+ * Class that deterministically generates 
+ * up to 2^64 unique IDs for AST nodes
+ *
+ * The IDs are unique for a given input
+ * so only pair (input; node) has a UID
+ * This means UidGenerator has to be reset
+ * For every new input
+ */
+class UidGenerator 
+{
+public:
+	uint64_t getUid() { return _counter++; }
+	void reset() { _counter = 0; }
+
+private:
+	uint64_t _counter = 0;
+};
+
+} // namespace yaramod

--- a/include/yaramod/parser/uid_generator.h
+++ b/include/yaramod/parser/uid_generator.h
@@ -22,11 +22,11 @@ namespace yaramod {
 class UidGenerator 
 {
 public:
-	uint64_t next() { return _counter++; }
+	std::uint64_t next() { return _counter++; }
 	void reset() { _counter = 0; }
 
 private:
-	uint64_t _counter = 0;
+	std::uint64_t _counter = 0;
 };
 
 } // namespace yaramod

--- a/include/yaramod/parser/uid_generator.h
+++ b/include/yaramod/parser/uid_generator.h
@@ -22,7 +22,7 @@ namespace yaramod {
 class UidGenerator 
 {
 public:
-	uint64_t getUid() { return _counter++; }
+	uint64_t next() { return _counter++; }
 	void reset() { _counter = 0; }
 
 private:

--- a/include/yaramod/types/expression.h
+++ b/include/yaramod/types/expression.h
@@ -57,7 +57,7 @@ public:
 
 	/// @name Getter methods
 	/// @{
-	uint64_t getUid() const { return _uid; }
+	std::uint64_t getUid() const { return _uid; }
 	Expression::Type getType() const { return _type; }
 	std::string getTypeString() const
 	{
@@ -88,7 +88,7 @@ public:
 
 	/// @name Setter methods
 	/// @{
-	void setUid(uint64_t uid) { _uid = uid; }
+	void setUid(std::uint64_t uid) { _uid = uid; }
 	void setType(Expression::Type type) { _type = type; }
 	void setTokenStream(const std::shared_ptr<TokenStream>& ts) { _tokenStream = ts; }
 	/// @}
@@ -160,7 +160,7 @@ protected:
 
 private:
 	Type _type; ///< Type of the expression
-	uint64_t _uid;
+	std::uint64_t _uid;
 };
 
 }

--- a/include/yaramod/types/expression.h
+++ b/include/yaramod/types/expression.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -56,6 +57,7 @@ public:
 
 	/// @name Getter methods
 	/// @{
+	uint64_t getUid() const { return _uid; }
 	Expression::Type getType() const { return _type; }
 	std::string getTypeString() const
 	{
@@ -86,6 +88,7 @@ public:
 
 	/// @name Setter methods
 	/// @{
+	void setUid(uint64_t uid) { _uid = uid; }
 	void setType(Expression::Type type) { _type = type; }
 	void setTokenStream(const std::shared_ptr<TokenStream>& ts) { _tokenStream = ts; }
 	/// @}
@@ -157,6 +160,7 @@ protected:
 
 private:
 	Type _type; ///< Type of the expression
+	uint64_t _uid;
 };
 
 }

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -1056,6 +1056,7 @@ void ParserDriver::defineGrammar()
 		.production("boolean", [&](auto&& args) -> Value {
 			auto output = std::make_shared<BoolLiteralExpression>(currentTokenStream(), args[0].getTokenIt());
 			output->setType(Expression::Type::Bool);
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_ID", [&](auto&& args) -> Value {
@@ -1068,6 +1069,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringExpression>(std::move(id));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_ID", "AT", "primary_expression", [&](auto&& args) -> Value {
@@ -1084,6 +1086,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringAtExpression>(id, op, std::move(expr));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_ID", "IN", "range", [&](auto&& args) -> Value {
@@ -1099,6 +1102,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringInRangeExpression>(id, op, std::move(range));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production(
@@ -1125,6 +1129,7 @@ void ParserDriver::defineGrammar()
 				auto output = std::make_shared<ForArrayExpression>(for_token, std::move(for_expr), id, op_in, std::move(set), lp, std::move(expr), rp);
 				output->setType(Expression::Type::Bool);
 				output->setTokenStream(currentTokenStream());
+				output->setUid(_uidGen.getUid());
 				return output;
 			}
 		)
@@ -1180,6 +1185,7 @@ void ParserDriver::defineGrammar()
 				auto output = std::make_shared<ForArrayExpression>(for_token, std::move(for_expr), id, op_in, std::move(array), lp, std::move(expr), rp);
 				output->setType(Expression::Type::Bool);
 				output->setTokenStream(currentTokenStream());
+				output->setUid(_uidGen.getUid());
 				return output;
 			}
 		)
@@ -1242,6 +1248,7 @@ void ParserDriver::defineGrammar()
 				auto output = std::make_shared<ForDictExpression>(for_token, std::move(for_expr), id1, comma, id2, op_in, std::move(dict), lp, std::move(expr), rp);
 				output->setType(Expression::Type::Bool);
 				output->setTokenStream(currentTokenStream());
+				output->setUid(_uidGen.getUid());
 				return output;
 			}
 		)
@@ -1267,6 +1274,7 @@ void ParserDriver::defineGrammar()
 				auto output = std::make_shared<ForStringExpression>(for_token, std::move(for_expr), of, std::move(set), lp, std::move(expr), rp);
 				output->setType(Expression::Type::Bool);
 				output->setTokenStream(currentTokenStream());
+				output->setUid(_uidGen.getUid());
 				stringLoopLeave();
 				return output;
 			}
@@ -1278,6 +1286,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<OfExpression>(std::move(for_expr), of, std::move(set));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("for_expression", "OF", "rule_set", [&](auto&& args) -> Value {
@@ -1287,6 +1296,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<OfExpression>(std::move(for_expr), of, std::move(set));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("for_expression", "OF", "string_set", "IN", "range", [&](auto&& args) -> Value {
@@ -1298,6 +1308,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<OfExpression>(std::move(for_expr), of, std::move(set), in, std::move(range));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "PERCENT", "OF", "string_set", [&](auto&& args) -> Value {
@@ -1319,6 +1330,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<OfExpression>(std::move(percentual_expr), of, std::move(set));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("NOT", "expression", [&](auto&& args) -> Value {
@@ -1327,6 +1339,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<NotExpression>(not_token, std::move(expr));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("DEFINED", "expression", [&](auto&& args) -> Value {
@@ -1335,6 +1348,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<DefinedExpression>(not_token, std::move(expr));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("expression", "AND", "expression", [&](auto&& args) -> Value {
@@ -1344,6 +1358,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<AndExpression>(std::move(left), and_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("expression", "OR", "expression", [&](auto&& args) -> Value {
@@ -1353,6 +1368,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<OrExpression>(std::move(left), or_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "LT", "primary_expression", [&](auto&& args) -> Value {
@@ -1362,6 +1378,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<LtExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "GT", "primary_expression", [&](auto&& args) -> Value {
@@ -1371,6 +1388,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<GtExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "LE", "primary_expression", [&](auto&& args) -> Value {
@@ -1380,6 +1398,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<LeExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "GE", "primary_expression", [&](auto&& args) -> Value {
@@ -1389,6 +1408,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<GeExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "EQ", "primary_expression", [&](auto&& args) -> Value {
@@ -1398,6 +1418,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<EqExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "NEQ", "primary_expression", [&](auto&& args) -> Value {
@@ -1407,6 +1428,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<NeqExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "CONTAINS", "primary_expression", [&](auto&& args) -> Value {
@@ -1420,6 +1442,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<ContainsExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "MATCHES", "regexp", [&](auto&& args) -> Value {
@@ -1432,6 +1455,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<MatchesExpression>(std::move(left), op_token, std::move(regexp_expression));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "IEQUALS", "primary_expression", [&](auto&& args) -> Value {
@@ -1445,6 +1469,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<IequalsExpression>(std::move(left), op_token, std::move(right));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", [](auto&& args) -> Value {
@@ -1456,6 +1481,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<ParenthesesExpression>(args[0].getTokenIt(), std::move(expr), args[2].getTokenIt());
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
@@ -1468,6 +1494,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<OfExpression>(std::move(for_expr), of, std::move(array));
 			output->setType(Expression::Type::Bool);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
@@ -1478,32 +1505,38 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<ParenthesesExpression>(args[0].getTokenIt(), std::move(args[1].getExpression()), args[2].getTokenIt());
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("FILESIZE", [&](auto&& args) -> Value {
 			auto output = std::make_shared<FilesizeExpression>(args[0].getTokenIt());
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("ENTRYPOINT", [&](auto&& args) -> Value {
 			auto output = std::make_shared<EntrypointExpression>(args[0].getTokenIt());
 			output->setType(Expression::Type::Int);
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("INTEGER", [&](auto&& args) -> Value {
 			auto output = std::make_shared<IntLiteralExpression>(currentTokenStream(), args[0].getTokenIt());
 			output->setType(Expression::Type::Int);
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("DOUBLE", [&](auto&& args) -> Value {
 			auto output = std::make_shared<DoubleLiteralExpression>(currentTokenStream(), args[0].getTokenIt());
 			output->setType(Expression::Type::Float);
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_LITERAL", [&](auto&& args) -> Value {
 			auto output = std::make_shared<StringLiteralExpression>(currentTokenStream(), args[0].getTokenIt());
 			output->setType(Expression::Type::String);
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_COUNT", [&](auto&& args) -> Value {
@@ -1519,6 +1552,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringCountExpression>(args[0].getTokenIt());
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_COUNT", "IN", "range", [&](auto&& args) -> Value {
@@ -1535,6 +1569,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringInRangeExpression>(args[0].getTokenIt(), args[1].getTokenIt(), std::move(range));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_OFFSET", [&](auto&& args) -> Value {
@@ -1550,6 +1585,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringOffsetExpression>(args[0].getTokenIt());
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_OFFSET", "LSQB", "primary_expression", "RSQB", [&](auto&& args) -> Value {
@@ -1565,6 +1601,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringOffsetExpression>(args[0].getTokenIt(), std::move(args[2].getExpression()));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_LENGTH", [&](auto&& args) -> Value {
@@ -1580,6 +1617,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringLengthExpression>(args[0].getTokenIt());
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_LENGTH", "LSQB", "primary_expression", "RSQB", [&](auto&& args) -> Value {
@@ -1595,6 +1633,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StringLengthExpression>(args[0].getTokenIt(), std::move(args[2].getExpression()));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("MINUS", "primary_expression", [&](auto&& args) -> Value {
@@ -1608,6 +1647,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<UnaryMinusExpression>(args[0].getTokenIt(), std::move(right));
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		}).precedence(3, pog::Associativity::Right)
 		.production("primary_expression", "PLUS", "primary_expression", [&](auto&& args) -> Value {
@@ -1621,6 +1661,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<PlusExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "MINUS", "primary_expression", [&](auto&& args) -> Value {
@@ -1634,6 +1675,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<MinusExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "MULTIPLY", "primary_expression", [&](auto&& args) -> Value {
@@ -1647,6 +1689,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<MultiplyExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "DIVIDE", "primary_expression", [&](auto&& args) -> Value {
@@ -1660,6 +1703,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<DivideExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(type);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "PERCENT", "primary_expression", [&](auto&& args) -> Value {
@@ -1672,6 +1716,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<ModuloExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "BITWISE_XOR", "primary_expression", [&](auto&& args) -> Value {
@@ -1684,6 +1729,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<BitwiseXorExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "BITWISE_AND", "primary_expression", [&](auto&& args) -> Value {
@@ -1696,6 +1742,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<BitwiseAndExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "BITWISE_OR", "primary_expression", [&](auto&& args) -> Value {
@@ -1708,6 +1755,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<BitwiseOrExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("BITWISE_NOT", "primary_expression", [&](auto&& args) -> Value {
@@ -1717,6 +1765,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<BitwiseNotExpression>(args[0].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "SHIFT_LEFT", "primary_expression", [&](auto&& args) -> Value {
@@ -1729,6 +1778,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<ShiftLeftExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("primary_expression", "SHIFT_RIGHT", "primary_expression", [&](auto&& args) -> Value {
@@ -1741,6 +1791,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<ShiftRightExpression>(std::move(left), args[1].getTokenIt(), std::move(right));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("INTEGER_FUNCTION", "LP", "primary_expression", "RP", [&](auto&& args) -> Value {
@@ -1749,6 +1800,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<IntFunctionExpression>(std::move(args[0].getTokenIt()), std::move(args[1].getTokenIt()), std::move(args[2].getExpression()), std::move(args[3].getTokenIt()));
 			output->setType(Expression::Type::Int);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("identifier", [](auto&& args) -> Value {
@@ -1758,6 +1810,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<RegexpExpression>(std::move(args[0].getYaramodString()));
 			output->setType(Expression::Type::Regexp);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;// end of primary_expression
@@ -1777,6 +1830,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<IdExpression>(symbol_token);
 			output->setType(symbol->getDataType());
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("identifier", "DOT", "ID", [&](auto&& args) -> Value {
@@ -1823,6 +1877,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<StructAccessExpression>(std::move(expr), args[1].getTokenIt(), symbol_token);
 			output->setType(symbol->getDataType());
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("identifier", "LSQB", "primary_expression", "RSQB", [&](auto&& args) -> Value {
@@ -1860,6 +1915,7 @@ void ParserDriver::defineGrammar()
 
 			output->setType(iterParentSymbol->getElementType());
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("identifier", "LP", "arguments", "RP", [&](auto&& args) -> Value {
@@ -1926,6 +1982,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<FunctionCallExpression>(std::move(expr), args[1].getTokenIt(), std::move(arguments), args[3].getTokenIt());
 			output->setType(funcParentSymbol->getReturnType());
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
@@ -1956,15 +2013,28 @@ void ParserDriver::defineGrammar()
 				error_handle(args[2].getTokenIt()->getLocation(), "operator '..' expects integer as upper bound of the interval");
 			auto output = std::make_shared<RangeExpression>(args[0].getTokenIt(), std::move(left), args[2].getTokenIt(), std::move(right), args[4].getTokenIt());
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
 
 	_parser.rule("for_expression") // Expression::Ptr
 		.production("primary_expression", [](auto&& args) -> Value { return std::move(args[0]); })
-		.production("ALL", [&](auto&& args) -> Value { return Value(std::make_shared<AllExpression>(currentTokenStream(), args[0].getTokenIt())); })
-		.production("ANY", [&](auto&& args) -> Value { return Value(std::make_shared<AnyExpression>(currentTokenStream(), args[0].getTokenIt())); })
-		.production("NONE", [&](auto&& args) -> Value { return Value(std::make_shared<NoneExpression>(currentTokenStream(), args[0].getTokenIt())); })
+		.production("ALL", [&](auto&& args) -> Value {
+			auto output = std::make_shared<AllExpression>(currentTokenStream(), args[0].getTokenIt());
+			output->setUid(_uidGen.getUid());
+			return output;
+		})
+		.production("ANY", [&](auto&& args) -> Value { 
+			auto output = std::make_shared<AnyExpression>(currentTokenStream(), args[0].getTokenIt()); 
+			output->setUid(_uidGen.getUid());
+			return output;
+		})
+		.production("NONE", [&](auto&& args) -> Value {
+			auto output = std::make_shared<NoneExpression>(currentTokenStream(), args[0].getTokenIt()); 
+			output->setUid(_uidGen.getUid());
+			return output;
+		})
 		;
 
 	_parser.rule("integer_set") // Expression::Ptr
@@ -1975,6 +2045,7 @@ void ParserDriver::defineGrammar()
 			rp->setType(TokenType::RP_ENUMERATION);
 			auto output = std::make_shared<SetExpression>(lp, std::move(args[1].getMultipleExpressions()), rp);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("range", [](auto&& args) -> Value {
@@ -2007,6 +2078,7 @@ void ParserDriver::defineGrammar()
 			rp->setType(TokenType::RP_ENUMERATION);
 			auto output = std::make_shared<SetExpression>(lp, std::move(args[1].getMultipleExpressions()), rp);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("THEM", [&](auto&& args) -> Value {
@@ -2034,6 +2106,7 @@ void ParserDriver::defineGrammar()
 				id->setValue(findStringDefinition(id->getString()));
 			auto output = std::make_shared<StringExpression>(id);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("STRING_ID_WILDCARD", [&](auto&& args) -> Value {
@@ -2042,6 +2115,7 @@ void ParserDriver::defineGrammar()
 				error_handle(id->getLocation(), "No string matched with wildcard '" + id->getPureText() + "'");
 			auto output = std::make_shared<StringWildcardExpression>(id);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
@@ -2054,6 +2128,7 @@ void ParserDriver::defineGrammar()
 			rp->setType(TokenType::RP_ENUMERATION);
 			auto output = std::make_shared<SetExpression>(lp, std::move(args[1].getMultipleExpressions()), rp);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
@@ -2088,6 +2163,7 @@ void ParserDriver::defineGrammar()
 			auto output = std::make_shared<IdExpression>(id);
 			output->setType(symbol->getDataType());
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		.production("ID", "MULTIPLY", [&](auto&& args) -> Value {
@@ -2101,6 +2177,7 @@ void ParserDriver::defineGrammar()
 
 			auto output = std::make_shared<IdWildcardExpression>(id, wildcard);
 			output->setTokenStream(currentTokenStream());
+			output->setUid(_uidGen.getUid());
 			return output;
 		})
 		;
@@ -2115,6 +2192,7 @@ void ParserDriver::defineGrammar()
 				rsqb->setType(TokenType::RSQB_ENUMERATION);
 				auto output = std::make_shared<IterableExpression>(lsqb, std::move(args[1].getMultipleExpressions()), rsqb);
 				output->setTokenStream(currentTokenStream());
+				output->setUid(_uidGen.getUid());
 				return output;
 			})
 			;
@@ -2279,6 +2357,8 @@ bool ParserDriver::parseImpl()
 void ParserDriver::reset(ParserMode parserMode)
 {
 	_mode = parserMode;
+
+	_uidGen.reset();
 
 	_strLiteral.clear();
 	_indent.clear();

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -14,6 +14,7 @@
 #include <yaramod/builder/yara_expression_builder.h>
 #include <yaramod/builder/yara_hex_string_builder.h>
 #include <yaramod/builder/yara_rule_builder.h>
+#include <yaramod/types/expression.h>
 #include <yaramod/types/plain_string.h>
 #include <yaramod/types/token_type.h>
 #include <yaramod/yaramod.h>
@@ -537,6 +538,7 @@ void addExpressionClasses(py::module& module)
 	py::class_<Expression, std::shared_ptr<Expression>>(module, "Expression")
 		.def("accept", &Expression::accept)
 		.def("get_text", &Expression::getText, py::arg("indent") = std::string{})
+		.def("get_uid", &Expression::getUid)
 		.def("exchange_tokens", py::overload_cast<Expression*>(&Expression::exchangeTokens))
 		.def_property_readonly("text",
 				// getText() has default parameter and Python can't deal with it

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -538,8 +538,8 @@ void addExpressionClasses(py::module& module)
 	py::class_<Expression, std::shared_ptr<Expression>>(module, "Expression")
 		.def("accept", &Expression::accept)
 		.def("get_text", &Expression::getText, py::arg("indent") = std::string{})
-		.def("get_uid", &Expression::getUid)
 		.def("exchange_tokens", py::overload_cast<Expression*>(&Expression::exchangeTokens))
+		.def_property_readonly("uid", [](const Expression& self) { return self.getUid();} )
 		.def_property_readonly("text",
 				// getText() has default parameter and Python can't deal with it
 				[](const Expression* self) {

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -539,7 +539,7 @@ void addExpressionClasses(py::module& module)
 		.def("accept", &Expression::accept)
 		.def("get_text", &Expression::getText, py::arg("indent") = std::string{})
 		.def("exchange_tokens", py::overload_cast<Expression*>(&Expression::exchangeTokens))
-		.def_property_readonly("uid", [](const Expression& self) { return self.getUid();} )
+		.def_property_readonly("uid", &Expression::getUid)
 		.def_property_readonly("text",
 				// getText() has default parameter and Python can't deal with it
 				[](const Expression* self) {

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -7938,5 +7938,32 @@ rule rule1
 	}
 }
 
+TEST_F(ParserTests,
+ExpressionUids) {
+	prepareInput(
+		R"(rule ExampleRule1
+{
+	strings:
+		$my_text_string = "text here" private
+		$my_hex_string = { E2 34 A1 C8 23 FB }
+		$a = "text1"
+		$b = "text2"
+		$c = "text3"
+		$d = "text4"
+	condition:
+		($a or $b) and ($c or $d)
+		or (#a == 6 and #b > 10) and
+		any of them
+}
+)");
+
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	auto yaraFile = driver.getParsedFile();
+	ASSERT_TRUE(yaraFile.hasRules());
+	ASSERT_EQ(21, yaraFile.getRules()[0]->getCondition()->getUid());
+	}
 }
 }

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -2220,3 +2220,22 @@ rule test_rule
 '''
 
         self.assertEqual(expected, yara_file.text_formatted)
+
+    def test_expression_uids(self):
+        yara_file = yaramod.Yaramod().parse_string(parser_mode=yaramod.ParserMode.Regular, str=r'''rule ExampleRule1
+{
+	strings:
+		$my_text_string = "text here" private
+		$my_hex_string = { E2 34 A1 C8 23 FB }
+		$a = "text1"
+		$b = "text2"
+		$c = "text3"
+		$d = "text4"
+	condition:
+		($a or $b) and ($c or $d)
+		or (#a == 6 and #b > 10) and
+		any of them
+}
+''')
+
+        self.assertEqual(yara_file.rules[0].condition.get_uid(), 21)

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -2238,4 +2238,4 @@ rule test_rule
 }
 ''')
 
-        self.assertEqual(yara_file.rules[0].condition.get_uid(), 21)
+        self.assertEqual(yara_file.rules[0].condition.uid, 21)


### PR DESCRIPTION
I've added UIDGenerator as part of the ParserDriver, which assigns UIDs to AST nodes that have `class Expression` as their base class.

The UIDs are supposed to be unique for a given input and deterministic, they are implemented using a 64bit resettable counter. The counter is reset when new parsing input is provided using the existing `prepareParser()` function and when the condition rule is applied, so it's reset before parsing each condition.

I've modified the existing rule condition AST dumper example code, to print the UIDs and for input:
```
rule ExampleRule
{
    strings:
        $my_text_string = "text here"
        $my_hex_string = { E2 34 A1 C8 23 FB }
        $a = "text1"
    condition:
        $my_text_string or $my_hex_string and
		not $a or false
}

rule ExampleRule1
{
    strings:
        $my_text_string = "text here" private
        $my_hex_string = { E2 34 A1 C8 23 FB }
        $a = "text1"
        $b = "text2"
        $c = "text3"
        $d = "text4"
    condition:
        ($a or $b) and ($c or $d)
        or (#a == 6 and #b > 10) and
        any of them
}

```
I get the following output:

```
==== RULE: ExampleRule
Or[0x55c587337c60]  uid=7
    Or[0x55c587335840]  uid=5
        String[0x55c587318880]  id=$my_text_string uid=0
        And[0x55c5873357d0]  uid=4
            String[0x55c587334230]  id=$my_hex_string uid=1
            Not[0x55c587332890]  uid=3
                String[0x55c587335720]  id=$a uid=2
    BoolLiteral[0x55c587337660]  value=false uid=6
==== RULE: ExampleRule1
Or[0x55c587346980]  uid=21
    And[0x55c5873414a0]  uid=8
        Parentheses[0x55c587340bb0]  uid=3
            Or[0x55c587340590]  uid=2
                String[0x55c58731b910]  id=$a uid=0
                String[0x55c587340540]  id=$b uid=1
        Parentheses[0x55c587341430]  uid=7
            Or[0x55c5873411c0]  uid=6
                String[0x55c587340f20]  id=$c uid=4
                String[0x55c587341170]  id=$d uid=5
    And[0x55c587346910]  uid=20
        Parentheses[0x55c587344c20]  uid=16
            And[0x55c587344ab0]  uid=15
                Equal[0x55c587343b40]  uid=11
                    StringCount[0x55c587342f20]  id=#a uid=9
                    IntLiteral[0x55c587343840]  value=6 uid=10
                GreaterThan[0x55c587344a40]  uid=14
                    StringCount[0x55c5873441b0]  id=#b uid=12
                    IntLiteral[0x55c5873449f0]  value=10 uid=13
        Of[0x55c587346870]  uid=19
            Any[0x55c5873464b0]  uid=17
            Them[0x55c587346820]  uid=18
 ```