### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ import re
 import subprocess
 import sys
 
-from distutils.command.build import build
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+from distutils.command.build import build
 
 
 script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022534