### PR TITLE
Use the right python to create `WRAP_MODULE_SOURCES`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,13 @@ if(YARAMOD_DOCS)
 endif()
 
 # Command that creates files in ${WRAP_MODULE_SOURCES}
+# simple call python won't work on macOS 12.3+
+# See: https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python
+find_package(Python REQUIRED COMPONENTS Interpreter)
 add_custom_command(
 	OUTPUT ${WRAP_MODULE_SOURCES}
 	# Create .h modules from .json modules
-	COMMAND	python ${YARAMOD_SCRIPTS_DIR}/json_to_array.py -i "${YARAMOD_MODULES_DIR}" -o "${YARAMOD_MODULES_GENERATED_DIR}"
+	COMMAND	${Python_EXECUTABLE} ${YARAMOD_SCRIPTS_DIR}/json_to_array.py -i "${YARAMOD_MODULES_DIR}" -o "${YARAMOD_MODULES_GENERATED_DIR}"
 	COMMENT
 		"Converting yaramod modules from JSON to byte arrays in .cpp files"
 )


### PR DESCRIPTION
Some system hasn't got python2 anymore, and ships only with python3. This mean that `python` command is unavailable.

This trivial patch started to use `find_package` to detect the real python binary which should be used.