### PR TITLE
ci: Be more explicit when excluding from matrix

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,16 +23,22 @@ jobs:
         exclude:
           - os: ubuntu-latest
             python-version: "3.8"
+            config: Release
           - os: ubuntu-latest
             python-version: "3.9"
+            config: Release
           - os: ubuntu-latest
             python-version: "3.10"
+            config: Release
           - os: macos-latest
             python-version: "3.8"
+            config: Release
           - os: macos-latest
             python-version: "3.9"
+            config: Release
           - os: macos-latest
             python-version: "3.10"
+            config: Release
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Not sure why is this necessary. Based on the documentation:

> An excluded configuration only has to be a partial match for it to be
> excluded.

this should work in the original form. And it seems it was working in the
past.