### PR TITLE
fix: Open json modules in read only mode

### DIFF
--- a/src/utils/json.cpp
+++ b/src/utils/json.cpp
@@ -15,7 +15,7 @@ namespace yaramod {
 
 nlohmann::json readJsonFile(const std::string& filePath)
 {
-	std::ifstream input{filePath, std::ios::out};
+	std::ifstream input{filePath};
 	if (!input.is_open())
 		throw YaramodError("Could not open '" + filePath);
 	std::stringstream buffer;

--- a/tests/python/test_modules.py
+++ b/tests/python/test_modules.py
@@ -1,0 +1,37 @@
+import yaramod
+
+def test_modules_that_are_readonly(tmp_path):
+    modules_directory = tmp_path
+    my_cuckoo_module = modules_directory / "my_cuckoo.json"
+    my_cuckoo_module.write_text('''{
+  "kind": "struct",
+  "name": "cuckoo",
+  "attributes": [
+    {
+      "kind": "function",
+      "name": "my_func",
+      "return_type": "i",
+      "overloads": [
+        {
+          "arguments": [
+            {
+              "type": "r",
+              "name": "data"
+            }
+          ],
+          "documentation": "Test"
+        }
+      ]
+    }
+  ]
+}
+''')
+    my_cuckoo_module.chmod(0o444)
+    ymod = yaramod.Yaramod(modules_directory=str(modules_directory))
+    yfile = ymod.parse_string(r'''import "cuckoo"
+rule test {
+    condition:
+        cuckoo.my_func(/.*/)
+}
+''')
+    assert yfile is not None


### PR DESCRIPTION
We had some cases when the modules were installed with read only permissions and yaramod would fail to open them.

Also we expect no writes to the modules json.

I removed the `std::ios::out` which opens the file in write mode. The default configuration is `std::ios_base::in`, which opens the file in read mode.