### PR TITLE
docs: Improve release docs

### DIFF
--- a/docs/rtd/deployment.rst
+++ b/docs/rtd/deployment.rst
@@ -5,7 +5,9 @@ Deployment
 A new version of Yaramod is released performing the following steps:
 
 * Open ``include/yaramod/yaramod.h`` and update ``YARAMOD_VERSION_PATCH`` (with big changes we also increment ``YARAMOD_VERSION_MINOR`` and set ``YARAMOD_VERSION_PATCH`` to 0).
+* Open ``docs/rtd/conf.py`` and update version in ``release =``.
 * In ``CHANGELOG.md`` add entry for the new version. List all important changes with links to issues and PRs.
 * Commit the changes with message "Release v<?>.<?>.<?>".
 * Create a git tag by running ``git tag -a v<?>.<?>.<?> -m "Release v<?>.<?>.<?>"``.
 * Push the new tag with ``git push origin v<?>.<?>.<?>``.
+* Push the commit after the release to master with ``git push origin master``.


### PR DESCRIPTION
I often forget to bump the version in the docs. So I added this as a step.

Additionally, after the current steps we don't have the release commit on the master branch. I am not sure if this was on purpose, but some older commits end up on master.

It can be because, if you push the commit without first releasing, GitHub will reject the push, because we have it set up to accept only tested commits. But after the release is done, we can push the commit to master since it is considered tested and passing from the release.

If we don't have the commits in master, it can be easy to accidentally bump the current version and release it without knowing there is already newer version that what is specified in master.