### PR TITLE
fix(parser): Fixed parsing of empty alternation groups (#193)

### DIFF
--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -993,6 +993,12 @@ void ParserDriver::defineGrammar()
 			std::shared_ptr<RegexpUnit> concat = std::make_shared<RegexpConcat>(args[2].getMultipleRegexpUnits());
 			return std::make_shared<RegexpOr>(std::move(arg), std::move(concat));
 		})
+		.production("regexp_or", "REGEXP_OR", [](auto&& args) -> Value {
+			// Special case in which we end alternation with empty string (like /(a|b|)/) which needs to be handled this way
+			// otherwise the grammar produces shift-reduce conflicts
+			std::shared_ptr<RegexpUnit> arg = std::move(args[0].getRegexpUnit());
+			return std::make_shared<RegexpOr>(std::move(arg), std::make_shared<RegexpText>(""));
+		})
 		;
 
 	_parser.rule("regexp_concat") // vector<shared_ptr<RegexpUnit>>

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -1441,6 +1441,40 @@ rule regexp_with_unescaped_square_brackets_inside_class
 }
 
 TEST_F(ParserTests,
+RegexpWithEmptyAlternationGroupWorks) {
+	prepareInput(
+R"(
+rule regexp_with_empty_alternation_group
+{
+	strings:
+		$1 = /(a|b|)/
+	condition:
+		all of them
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ("regexp_with_empty_alternation_group", rule->getName());
+	EXPECT_EQ(Rule::Modifier::None, rule->getModifier());
+
+	auto strings = rule->getStrings();
+	ASSERT_EQ(1u, strings.size());
+
+	auto regexp1 = strings[0];
+	EXPECT_TRUE(regexp1->isRegexp());
+	EXPECT_EQ("$1", regexp1->getIdentifier());
+	EXPECT_EQ(R"(/(a|b|)/)", regexp1->getText());
+
+	EXPECT_EQ("all", rule->getCondition()->getFirstTokenIt()->getPureText());
+	EXPECT_EQ("them", rule->getCondition()->getLastTokenIt()->getPureText());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 InvalidCuckooRuleAccessTokenStream) {
 	prepareInput(
 R"(


### PR DESCRIPTION
This fixes parsing of regexes like `/(a|b|)/` which are valid YARA but we weren't able to handle empty alternation groups. Fixes #193.