### PR TITLE
String literal sets

### DIFF
--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3191,7 +3191,7 @@ rule for_string_literal_set_condition
 	catch (const ParserError& err)
 	{
 		EXPECT_EQ(0u, driver.getParsedFile().getRules().size());
-		EXPECT_EQ("Error at 7.27: all items in enumerations must be same type", err.getErrorMessage());
+		EXPECT_EQ("Error at 7.27: all items in enumeration must be same type", err.getErrorMessage());
 	}
 }
 

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3098,6 +3098,54 @@ rule for_string_set_condition
 }
 
 TEST_F(ParserTests,
+ForStringLiteralSetConditionWorks) {
+	prepareInput(
+R"(
+import "pe"
+
+rule for_string_literal_set_condition
+{
+	condition:
+		for any s in ("hash1", "hash2", "hash3") : ( pe.imphash() == s )
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ("for any s in (\"hash1\", \"hash2\", \"hash3\") : ( pe.imphash() == s )", rule->getCondition()->getText());
+	EXPECT_EQ("for", rule->getCondition()->getFirstTokenIt()->getPureText());
+	EXPECT_EQ(")", rule->getCondition()->getLastTokenIt()->getPureText());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ForStringLiteralSetWithOneStringConditionWorks) {
+	prepareInput(
+R"(
+import "pe"
+
+rule for_string_literal_set_condition
+{
+	condition:
+		for any s in ("hash1") : ( pe.imphash() == s )
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ("for any s in (\"hash1\") : ( pe.imphash() == s )", rule->getCondition()->getText());
+	EXPECT_EQ("for", rule->getCondition()->getFirstTokenIt()->getPureText());
+	EXPECT_EQ(")", rule->getCondition()->getLastTokenIt()->getPureText());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 NoneOfThemConditionWorks) {
 	prepareInput(
 R"(

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -3146,6 +3146,56 @@ rule for_string_literal_set_condition
 }
 
 TEST_F(ParserTests,
+ForStringLiteralSetWithStringSymbolsConditionWorks) {
+	prepareInput(
+R"(
+import "pe"
+import "elf"
+
+rule for_string_literal_set_condition
+{
+	condition:
+		for any s in ("hash1", elf.dynsym [ 0 ].name, pe.imphash ( )) : ( "abc123" == s )
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ("for any s in (\"hash1\", elf.dynsym[0].name, pe.imphash()) : ( \"abc123\" == s )", rule->getCondition()->getText());
+	EXPECT_EQ("for", rule->getCondition()->getFirstTokenIt()->getPureText());
+	EXPECT_EQ(")", rule->getCondition()->getLastTokenIt()->getPureText());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
+ForExpressionSetWithItemsVariousTypesForbidden) {
+	prepareInput(
+R"(
+import "pe"
+
+rule for_string_literal_set_condition
+{
+	condition:
+		for any s in ("hash1", 1, "hash3") : ( pe.imphash() == s )
+}
+)");
+
+	try
+	{
+		driver.parse(input);
+		FAIL() << "Parser did not throw an exception.";
+	}
+	catch (const ParserError& err)
+	{
+		EXPECT_EQ(0u, driver.getParsedFile().getRules().size());
+		EXPECT_EQ("Error at 7.27: all items in enumerations must be same type", err.getErrorMessage());
+	}
+}
+
+TEST_F(ParserTests,
 NoneOfThemConditionWorks) {
 	prepareInput(
 R"(

--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -1367,6 +1367,37 @@ rule rule_with_dictionary_access_condition {
 	condition:
 		for any i in (1, 2, 3) : ( $1 at (entrypoint + i) )
 }''')
+                         
+    def test_rule_with_string_literal_set(self):
+        cond = yaramod.for_loop(
+                yaramod.any(),
+                's',
+                yaramod.set([
+                    yaramod.string_val('hash1'),
+                    yaramod.string_val('hash2'),
+                    yaramod.string_val('hash3')
+                ]),
+                yaramod.id('s') == yaramod.string_val('abc123')
+            )
+        rule = self.new_rule \
+            .with_name('rule_with_string_literal_set') \
+            .with_condition(cond.get()) \
+            .get()
+        yara_file = self.new_file \
+            .with_rule(rule) \
+            .get()
+
+
+        self.assertEqual(yara_file.text_formatted, '''rule rule_with_string_literal_set
+{
+	condition:
+		for any s in ("hash1", "hash2", "hash3") : ( s == "abc123" )
+}
+''')
+        self.assertEqual(yara_file.text, '''rule rule_with_string_literal_set {
+	condition:
+		for any s in ("hash1", "hash2", "hash3") : ( s == "abc123" )
+}''')
 
     def test_rule_with_string_modifiers(self):
         rule = self.new_rule \

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -1173,6 +1173,24 @@ rule for_integer_set_condition {
         self.assertTrue(isinstance(rule.condition.body, yaramod.IdExpression))
         self.assertEqual(rule.condition.text, 'for all i in (1, 2, 3) : ( i )')
 
+    def test_for_string_literal_set_condition(self):
+        yara_file = yaramod.Yaramod().parse_string('''
+import "pe"
+
+rule for_integer_set_condition {
+    condition:
+        for all i in ("hash1","hash2","hash3") : ( i == pe.imphash() )
+}''')
+
+        self.assertEqual(len(yara_file.rules), 1)
+
+        rule = yara_file.rules[0]
+        self.assertTrue(isinstance(rule.condition, yaramod.ForArrayExpression))
+        self.assertTrue(isinstance(rule.condition.variable, yaramod.AllExpression))
+        self.assertTrue(isinstance(rule.condition.iterable, yaramod.SetExpression))
+        self.assertTrue(isinstance(rule.condition.body, yaramod.EqExpression))
+        self.assertEqual(rule.condition.text, 'for all i in ("hash1", "hash2", "hash3") : ( i == pe.imphash() )')
+
     def test_for_array_condition(self):
         yara_file = yaramod.Yaramod().parse_string('''
 import "pe"


### PR DESCRIPTION
Added support for string literal sets, that are supported in YARA 4.3. Also added corresponding parser and builder tests.