### PR TITLE
Added deferred include parsing mode + fixed incomplete mode when import of a module is missing

### DIFF
--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -40,7 +40,8 @@ enum class ParserMode
 {
 	Regular, ///< In this mode, parser behaves like regular YARA parser
 	IncludeGuarded, ///< Parser provides protection against inclusion of the same file multiple times
-	Incomplete ///< Parser enables to parse incomplete rules: referencing unknown symbols or rules that have been not finished properly (e.g. "rule abc {strings:")
+	Incomplete, ///< Parser enables to parse incomplete rules: referencing unknown symbols or rules that have been not finished properly (e.g. "rule abc {strings:")
+	DeferredInclude, ///< Extension of Incomplete mode which additionally does not resolve includes and just stores file paths for user to resolve them manually if needed
 };
 
 /**
@@ -123,7 +124,8 @@ protected:
 
 	/// @name Method for obtaining info about parser
 	/// @{
-	bool incompleteMode() const { return _mode == ParserMode::Incomplete; }
+	bool deferredIncludeMode() const { return _mode == ParserMode::DeferredInclude; }
+	bool incompleteMode() const { return _mode == ParserMode::Incomplete || _mode == ParserMode::DeferredInclude; }
 	/// @}
 
 	/// @name Methods for handling includes
@@ -194,6 +196,11 @@ protected:
 	Rule createCommonRule(std::vector<yaramod::Value>& args);
 	/// @}
 
+	/// @name Deferred includes
+	/// @{
+	void addDeferredInclude(std::string&& filePath);
+	/// @}
+
 private:
 	std::string _strLiteral; ///< Currently processed string literal.
 	Location::Position _positionBegin; ///< Variable storing the position the currently processed token begins at.
@@ -229,6 +236,7 @@ private:
 	std::shared_ptr<TokenStream> _lastRuleTokenStream; ///< Holds token stream at the point of where last parsed rule starts
 	std::uint64_t _anonStringCounter; ///< Internal counter for generating pseudo identifiers of anonymous strings
 	Location _errorLocation; ///< Last known location before error in parsing happened.
+	std::vector<std::string> _deferredIncludes;
 };
 
 } // namespace yaramod

--- a/include/yaramod/types/yara_file.h
+++ b/include/yaramod/types/yara_file.h
@@ -106,6 +106,12 @@ public:
 	std::vector<std::string> expandRulePrefixFromOrigin(const std::string& prefix, yaramod::Rule* origin) const;
 	/// @}
 
+	/// @name Deferred includes
+	/// @{
+	const std::vector<std::string>& getDeferredIncludes() const;
+	void addDeferredInclude(std::string&& filePath);
+	/// @}
+
 private:
 	void initializeVTSymbols();
 
@@ -119,6 +125,7 @@ private:
 
 	Features _Features; ///< Determines which symbols are needed
 	std::vector<std::shared_ptr<Symbol>> _vtSymbols; ///< Virust Total symbols
+	std::vector<std::string> _deferredIncludes;
 };
 
 }

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,7 +11,7 @@ pybind11_add_module(yaramod-python
 # It seems like -O2 and -O3 produce some kind of different template instantiation which is not compatible
 # with other compiler options use when compiling python extension.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	set(CMAKE_CXX_FLAGS_RELEASE "-O1 -DNDEBUG")
+	#	set(CMAKE_CXX_FLAGS_RELEASE "-O1 -DNDEBUG")
 endif()
 
 set_target_properties(yaramod-python PROPERTIES OUTPUT_NAME "yaramod")

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -67,7 +67,8 @@ void addEnums(py::module& module)
 	py::enum_<ParserMode>(module, "ParserMode")
 		.value("Regular", ParserMode::Regular)
 		.value("IncludeGuarded", ParserMode::IncludeGuarded)
-		.value("Incomplete", ParserMode::Incomplete);
+		.value("Incomplete", ParserMode::Incomplete)
+		.value("DeferredInclude", ParserMode::DeferredInclude);
 
 	py::enum_<Features>(module, "Features", py::arithmetic())
 		.value("Basic", Features::Basic)
@@ -284,7 +285,8 @@ void addBasicClasses(py::module& module)
 		.def("remove_imports", [](YaraFile& self, const std::function<bool(const std::shared_ptr<Module>&)>& pred) {
 				self.removeImports(pred);
 			})
-		.def("expand_rule_prefix_from_origin", &YaraFile::expandRulePrefixFromOrigin);
+		.def("expand_rule_prefix_from_origin", &YaraFile::expandRulePrefixFromOrigin)
+		.def("deferred_includes", &YaraFile::getDeferredIncludes);
 
 	py::class_<Location>(module, "Location")
 		.def_property_readonly("file_path", &Location::getFilePath)

--- a/src/types/yara_file.cpp
+++ b/src/types/yara_file.cpp
@@ -29,6 +29,8 @@ YaraFile::YaraFile(const std::shared_ptr<TokenStream>& tokenStream, Features fea
 	, _ruleTable()
 	, _ruleTrie()
 	, _Features(features)
+	, _vtSymbols()
+	, _deferredIncludes()
 {
 	if (_Features & Features::VirusTotalOnly)
 		initializeVTSymbols();
@@ -43,6 +45,7 @@ YaraFile::YaraFile(YaraFile&& o) noexcept
 	, _ruleTrie(std::move(o._ruleTrie))
 	, _Features(std::move(o._Features))
 	, _vtSymbols(std::move(o._vtSymbols))
+	, _deferredIncludes(std::move(o._deferredIncludes))
 {
 }
 
@@ -478,6 +481,16 @@ std::vector<std::string> YaraFile::expandRulePrefixFromOrigin(const std::string&
 	}
 
 	return result;
+}
+
+const std::vector<std::string>& YaraFile::getDeferredIncludes() const
+{
+	return _deferredIncludes;
+}
+
+void YaraFile::addDeferredInclude(std::string&& filePath)
+{
+	_deferredIncludes.push_back(std::move(filePath));
 }
 
 }

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -8495,5 +8495,27 @@ rule string_module
 	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
 }
 
+TEST_F(ParserTests,
+IncompleteModeWithModulesWorks) {
+	prepareInput(
+R"(
+rule module_rule
+{
+	condition:
+		pe.import_details[0].rva == 0x1234 and
+		string.to_int("1234") == 1234
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input, ParserMode::Incomplete));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ(R"(pe.import_details[0].rva == 0x1234 and string.to_int("1234") == 1234)", rule->getCondition()->getText());
+	EXPECT_EQ(2u, driver.getParsedFile().getImports().size());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
 }
 }


### PR DESCRIPTION
This change adds new deferred include parsing mode which is an extension of incomplete parsing mode. On top of allowing rules to use undefined symbols, it additionally does not resolve include directives and let's user to handle them.

Incomplete mode was also broken for a long time by not allowing to parse incomplete rules when they used a module for which the definition was missing. This change forces the import of said module.