### PR TITLE
feat: Builder now creates new types of iterables with iterable()

### DIFF
--- a/src/builder/yara_expression_builder.cpp
+++ b/src/builder/yara_expression_builder.cpp
@@ -1271,19 +1271,19 @@ YaraExpressionBuilder ofAt(const YaraExpressionBuilder& quantifier, const YaraEx
 YaraExpressionBuilder iterable(const std::vector<YaraExpressionBuilder>& elements)
 {
 	auto ts = std::make_shared<TokenStream>();
-	TokenIt lsqb = ts->emplace_back(TokenType::LSQB_ENUMERATION, "[");
+	TokenIt lb = ts->emplace_back(TokenType::LP_ENUMERATION, "(");
 	for (std::size_t i = 0; i < elements.size(); ++i)
 	{
 		ts->moveAppend(elements[i].getTokenStream());
 		if (i < elements.size() - 1)
 			ts->emplace_back(TokenType::COMMA, ",");
 	}
-	TokenIt rsqb = ts->emplace_back(TokenType::RSQB_ENUMERATION, "]");
+	TokenIt rb = ts->emplace_back(TokenType::RP_ENUMERATION, ")");
 
 	std::vector<Expression::Ptr> elementsExprs;
 	std::for_each(elements.begin(), elements.end(), [&elementsExprs](const YaraExpressionBuilder& expr) { elementsExprs.push_back(expr.get()); });
 
-	auto expression = std::make_shared<IterableExpression>(lsqb, std::move(elementsExprs), rsqb);
+	auto expression = std::make_shared<IterableExpression>(lb, std::move(elementsExprs), rb);
 	return YaraExpressionBuilder(std::move(ts), std::move(expression));
 }
 

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -2413,5 +2413,40 @@ WithWorks) {
 )", yaraFile->getTextFormatted());
 }
 
+TEST_F(BuilderTests,
+IterableWorks) {
+	auto cond = of(
+		any(),
+		iterable({
+			intVal(1),
+			intVal(2)
+		})
+	).get();
+
+	YaraRuleBuilder newRule;
+	auto rule = newRule
+			.withName("iterable_builder")
+			.withCondition(cond)
+			.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+			.withRule(std::move(rule))
+			.get(true);
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(rule iterable_builder {
+	condition:
+		any of (1, 2)
+})", yaraFile->getText());
+
+	EXPECT_EQ(R"(rule iterable_builder
+{
+	condition:
+		any of (1, 2)
+}
+)", yaraFile->getTextFormatted());
+}
+
 }
 }

--- a/tests/cpp/visitor_tests.cpp
+++ b/tests/cpp/visitor_tests.cpp
@@ -816,7 +816,7 @@ rule rule_name {
 	variables:
 		var = 1.5
 	condition:
-		(true and all of ["string"=="strong" and var<3.0, true, time.now() < 1000]) or false
+		(true and all of ("string"=="strong" and var<3.0, true, time.now() < 1000)) or false
 }
 )");
 	EXPECT_TRUE(driver.parse(input));
@@ -828,7 +828,7 @@ rule rule_name {
 	visitor.process_rule(rule);
 
 	EXPECT_EQ("rule_name", rule->getName());
-	EXPECT_EQ("(true and all of [var > 5.5, time.now() > 500]) or false", rule->getCondition()->getText());
+	EXPECT_EQ("(true and all of (var > 5.5, time.now() > 500)) or false", rule->getCondition()->getText());
 
 	std::string expected = R"(import "time"
 
@@ -839,7 +839,7 @@ rule rule_name
 	condition:
 		(
 			true and
-			all of [ var > 5.5, time.now() > 500 ]
+			all of (var > 5.5, time.now() > 500)
 		) or
 		false
 }


### PR DESCRIPTION
The iterables should now be preferred to have parantheses and not square brackets.