### PR TITLE
Several formatting fixes

### DIFF
--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -2196,7 +2196,11 @@ void ParserDriver::defineGrammar()
 				}
 			}
 
-			auto output = std::make_shared<FunctionCallExpression>(std::move(expr), args[1].getTokenIt(), std::move(arguments), args[3].getTokenIt());
+			auto lp = args[1].getTokenIt();
+			auto rp = args[3].getTokenIt();
+			lp->setType(TokenType::FUNCTION_CALL_LP);
+			rp->setType(TokenType::FUNCTION_CALL_RP);
+			auto output = std::make_shared<FunctionCallExpression>(std::move(expr), std::move(lp), std::move(arguments), std::move(rp));
 			output->setType(funcParentSymbol->getReturnType());
 			output->setTokenStream(currentTokenStream());
 			output->setUid(_uidGen.next());

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -994,13 +994,28 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 					}
 			}
 		}
-		else if (inside_enumeration_brackets > 0)
+		else if (inside_enumeration_brackets > 0 && !inside_regexp)
 		{
-			if ((current != TokenType::LP_ENUMERATION && next != TokenType::RP_ENUMERATION) && (current != TokenType::LSQB_ENUMERATION && next != TokenType::RSQB_ENUMERATION) && current != TokenType::DOT && next != TokenType::COMMA && next != TokenType::DOT && next != TokenType::NEW_LINE)
-			{
+			if (
+				(current != TokenType::LP_ENUMERATION && next != TokenType::RP_ENUMERATION)
+				&& (current != TokenType::LSQB_ENUMERATION && next != TokenType::RSQB_ENUMERATION)
+				&& current != TokenType::DOT
+				&& next != TokenType::COMMA
+				&& next != TokenType::DOT
+				&& next != TokenType::NEW_LINE
+				&& next != TokenType::LSQB
+				&& next != TokenType::RSQB
+				&& current != TokenType::LSQB
 				// we ran into <rule_id>* and we don't want space in between them
-				if (!(current == TokenType::ID_WILDCARD && next == TokenType::ID_WILDCARD))
-					helper.insertIntoStream(os, ' ');
+				&& !(current == TokenType::ID_WILDCARD && next == TokenType::ID_WILDCARD)
+				// Function followed by ( should not have space in between
+				&& !(current == TokenType::FUNCTION_SYMBOL && next == TokenType::FUNCTION_CALL_LP)
+				// Immediatelly after ( shoudl not be a space
+				&& current != TokenType::FUNCTION_CALL_LP
+				// Immediately before ) should not be a space
+				&& next != TokenType::FUNCTION_CALL_RP
+			) {
+				helper.insertIntoStream(os, ' ');
 			}
 		}
 		else if (current == TokenType::HEX_ALT_RIGHT_BRACKET || current == TokenType::HEX_ALT_LEFT_BRACKET)

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -816,7 +816,7 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 	bool inside_hex_string = false;
 	bool inside_hex_jump = false;
 	bool inside_regexp = false;
-	uint32_t inside_enumeration_brackets = 0;
+	int inside_enumeration_brackets = 0;
 	bool inside_string_modifiers = false;
 	bool inside_string_modifiers_arguments = false;
 	bool inside_condition_section = false;
@@ -877,7 +877,7 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 		else if (current == TokenType::LP_ENUMERATION)
 			inside_enumeration_brackets += 1;
 		else if (current == TokenType::RP_ENUMERATION)
-			inside_enumeration_brackets -= 1;
+			inside_enumeration_brackets = std::max(inside_enumeration_brackets - 1, 0);
 		else if (it->isStringModifier())
 			inside_string_modifiers = true;
 

--- a/src/types/token_stream.cpp
+++ b/src/types/token_stream.cpp
@@ -816,7 +816,7 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 	bool inside_hex_string = false;
 	bool inside_hex_jump = false;
 	bool inside_regexp = false;
-	bool inside_enumeration_brackets = false;
+	uint32_t inside_enumeration_brackets = 0;
 	bool inside_string_modifiers = false;
 	bool inside_string_modifiers_arguments = false;
 	bool inside_condition_section = false;
@@ -875,9 +875,9 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 		else if (current == TokenType::REGEXP_END_SLASH)
 			inside_regexp = false;
 		else if (current == TokenType::LP_ENUMERATION)
-			inside_enumeration_brackets = true;
+			inside_enumeration_brackets += 1;
 		else if (current == TokenType::RP_ENUMERATION)
-			inside_enumeration_brackets = false;
+			inside_enumeration_brackets -= 1;
 		else if (it->isStringModifier())
 			inside_string_modifiers = true;
 
@@ -948,7 +948,7 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 					helper.insertIntoStream(os, ' ');
 			}
 		}
-		else if (!inside_regexp && !inside_enumeration_brackets && !inside_string_modifiers_arguments)
+		else if (!inside_regexp && inside_enumeration_brackets == 0 && !inside_string_modifiers_arguments)
 		{
 			switch(current)
 			{
@@ -994,7 +994,7 @@ void TokenStream::getTextProcedure(PrintHelper& helper, std::stringstream* os, b
 					}
 			}
 		}
-		else if (inside_enumeration_brackets)
+		else if (inside_enumeration_brackets > 0)
 		{
 			if ((current != TokenType::LP_ENUMERATION && next != TokenType::RP_ENUMERATION) && (current != TokenType::LSQB_ENUMERATION && next != TokenType::RSQB_ENUMERATION) && current != TokenType::DOT && next != TokenType::COMMA && next != TokenType::DOT && next != TokenType::NEW_LINE)
 			{


### PR DESCRIPTION
Formatting of token stream worked incorrectly with new expression arrays (using regular parentheses instead of square brackets) and it was producing broken YARA files.

This not only fixes that, but also fixes:

* Formatting for nested expression arrays which didn't work properly even before
* Forcing correct spacing around function calls and arrays accesses (with no spaces around these brackets)

And I also added test for testing all of this since it seems like it wasn't really covered.