### PR TITLE
ci: Add wheels for linux/arm64

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -155,6 +155,9 @@ jobs:
           - runs-on: ubuntu-latest
             platform: linux
             arch: manylinux_x86_64
+          - runs-on: ubuntu-24.04-arm
+            platform: linux
+            arch: manylinux_aarch64
           - runs-on: windows-latest
             platform: windows
             arch: win_amd64


### PR DESCRIPTION
When running in Docker on linux/arm64 arch, the wheels are not available and are being built from sources. This requires additional installation of `cmake` and `build-essentials` on Python Docker images. 
⚠️ I do not have access to a list of available Github runners, I just used [documentation](https://github.com/actions/partner-runner-images?tab=readme-ov-file#available-images) to get name of proper runner.