### PR TITLE
Add exclusive module paths API to bypass built-in modules

### DIFF
--- a/docs/rtd/getting_started.rst
+++ b/docs/rtd/getting_started.rst
@@ -67,3 +67,28 @@ you to create one instance per thread or process.
 * *VirusTotal* - You are interested in basic and VirusTotal-specific symbols.
 
 The second option enables you to supply custom modules other than YARA upstream modules. Simply enter the path to the directory where your modules are stored as `json` files.
+
+Exclusive module paths
+----------------------
+
+If you want to use **only** your own module definitions and skip all built-in modules, you can pass a list of JSON file paths via the *module_paths* parameter (Python) or a ``std::vector<std::string>`` (C++). When this parameter is used, built-in modules are not loaded at all.
+
+.. code-block:: python
+
+    import yaramod
+
+    # Only the time module is available — no pe, hash, etc.
+    ym = yaramod.Yaramod(
+        yaramod.Features.AllCurrent,
+        module_paths=["/path/to/module_time.json"],
+    )
+
+.. code-block:: cpp
+
+    // C++ equivalent
+    yaramod::Yaramod ym(
+        yaramod::Features::AllCurrent,
+        std::vector<std::string>{"/path/to/module_time.json"}
+    );
+
+Passing an empty list creates a ``Yaramod`` instance with no modules at all. This is the programmatic equivalent of setting the ``YARAMOD_MODULE_SPEC_PATH_EXCLUSIVE`` environment variable.

--- a/include/yaramod/parser/parser_driver.h
+++ b/include/yaramod/parser/parser_driver.h
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #define FMT_HEADER_ONLY 1
 
@@ -89,6 +90,7 @@ public:
 	/// @name Constructors
 	/// @{
 	ParserDriver(Features features = Features::AllCurrent, const std::string& moduleDirectory = "");
+	ParserDriver(Features features, const std::vector<std::string>& exclusiveModulePaths);
 	ParserDriver(Features features, const std::shared_ptr<ModulePool>& modulePool);
 	/// @}
 

--- a/include/yaramod/types/modules/module_pool.h
+++ b/include/yaramod/types/modules/module_pool.h
@@ -12,6 +12,7 @@
 #include "yaramod/types/modules/module.h"
 
 #include <map>
+#include <vector>
 
 namespace yaramod {
 
@@ -31,6 +32,17 @@ public:
 	 */
 	ModulePool(Features features, const std::string& directory);
 	/**
+	 * Constructor with exclusive module paths.
+	 *
+	 * When exclusiveModulePaths is non-empty, only modules from those paths are loaded.
+	 * Built-in modules are skipped entirely. Environment variables are still respected
+	 * and take precedence.
+	 *
+	 * @param features Determines which symbols to import
+	 * @param exclusiveModulePaths Paths to JSON files defining modules exclusively
+	 */
+	ModulePool(Features features, const std::vector<std::string>& exclusiveModulePaths);
+	/**
 	 * Loads the module based on its name from the table of known modules.
 	 *
 	 * @param name Name of the module to load
@@ -48,7 +60,7 @@ public:
 	std::map<std::string, Module*> getModules() const;
 
 private:
-	void _init(const std::string& directory);
+	void _init(const std::string& directory, bool loadBuiltinModules = true);
 	bool _processPath(fs::path path);
 	void _processModuleContent(const ModuleContent& content);
 	Features _features;

--- a/include/yaramod/yaramod.h
+++ b/include/yaramod/yaramod.h
@@ -19,6 +19,7 @@
 #define YARA_SYNTAX_VERSION "x-0.12.0"
 
 #include <memory>
+#include <vector>
 
 #include "yaramod/builder/yara_file_builder.h"
 #include "yaramod/parser/parser_driver.h"
@@ -29,13 +30,22 @@ namespace yaramod {
 class Yaramod
 {
 public:
-	/*
+	/**
 	 * Constructor
 	 *
-	 * @param features determines iff we want to use aditional Avast-specific symbols or VirusTotal-specific symbols in the imported modules
+	 * @param features determines which symbols to import from modules
 	 * @param moduleDirectory determines a directory for additional YARA modules to be added
 	 */
-	Yaramod(Features features = Features::AllCurrent, const std::string& moduleDirectory = "") : _driver(features, moduleDirectory)	{}
+	Yaramod(Features features = Features::AllCurrent, const std::string& moduleDirectory = "") : _driver(features, moduleDirectory) {}
+	/**
+	 * Constructor with exclusive module paths.
+	 *
+	 * Only modules from the provided file paths are loaded. Built-in modules are skipped.
+	 *
+	 * @param features determines which symbols to import from modules
+	 * @param exclusiveModulePaths paths to JSON files defining modules exclusively
+	 */
+	Yaramod(Features features, const std::vector<std::string>& exclusiveModulePaths) : _driver(features, exclusiveModulePaths) {}
 	/**
 	 * Parses file at given path.
 	 *

--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -2530,6 +2530,18 @@ ParserDriver::ParserDriver(Features features, const std::string& moduleDirectory
 	initialize();
 }
 
+ParserDriver::ParserDriver(Features features, const std::vector<std::string>& exclusiveModulePaths)
+	: _strLiteral(), _indent(), _comment(), _regexpClass(), _parser(), _sectionStrings(false),
+	_escapedContent(false), _mode(ParserMode::Regular), _features(features),
+	_modules(std::make_shared<ModulePool>(features, exclusiveModulePaths)),
+	_fileContexts(), _comments(), _includedFiles(), _includedFilesCache(), _valid(false),
+	_file(), _currentStrings(), _stringLoop(false), _localSymbols(), _lastRuleLocation(),
+	_lastRuleTokenStream(), _anonStringCounter(0), _errorLocation(), _deferredIncludes(),
+	_expressionArrayStack()
+{
+	initialize();
+}
+
 ParserDriver::ParserDriver(Features features, const std::shared_ptr<ModulePool>& modulePool)
 	: _strLiteral(), _indent(), _comment(), _regexpClass(), _parser(), _sectionStrings(false),
 	_escapedContent(false), _mode(ParserMode::Regular), _features(features), _modules(modulePool),

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -1029,6 +1029,7 @@ void addMainClass(py::module& module)
 {
 	py::class_<Yaramod>(module, "Yaramod")
 		.def(py::init<Features, const std::string&>(), py::arg("import_features") = Features::AllCurrent, py::arg("modules_directory") = "")
+		.def(py::init<Features, const std::vector<std::string>&>(), py::arg("import_features"), py::arg("module_paths"))
 		.def("parse_file", &Yaramod::parseFile, py::arg("file_path"), py::arg("parser_mode") = ParserMode::Regular)
 		.def("parse_string", [](Yaramod& self, const std::string& str, ParserMode parserMode) {
 				std::istringstream stream(str);

--- a/src/types/modules/module_pool.cpp
+++ b/src/types/modules/module_pool.cpp
@@ -24,6 +24,18 @@ ModulePool::ModulePool(Features features, const std::string& directory)
 		itr->second->initialize();
 }
 
+ModulePool::ModulePool(Features features, const std::vector<std::string>& exclusiveModulePaths)
+	: _features(features)
+{
+	for (const auto& path : exclusiveModulePaths)
+		_processPath(fs::path(path));
+
+	_init("", false);
+
+	for (auto itr = _knownModules.begin(); itr != _knownModules.end(); ++itr)
+		itr->second->initialize();
+}
+
 std::shared_ptr<Module> ModulePool::load(const std::string& name)
 {
 	auto itr = _knownModules.find(name);
@@ -100,7 +112,7 @@ void ModulePool::_processModuleContent(const ModuleContent& content)
 		itr->second->addJson(std::move(json));
 }
 
-void ModulePool::_init(const std::string& directory)
+void ModulePool::_init(const std::string& directory, bool loadBuiltinModules)
 {
 	if (const char* envProperty = std::getenv("YARAMOD_MODULE_SPEC_PATH_EXCLUSIVE"))
 	{
@@ -134,8 +146,11 @@ void ModulePool::_init(const std::string& directory)
 			if (!foundModules)
 				throw ModuleError("Directory '" + directory + "' does not contain single valid module. If you want to use public modules, set directory=\"\".");
 		}
-		for (const auto& content : _moduleList.list)
-			_processModuleContent(content);
+		if (loadBuiltinModules)
+		{
+			for (const auto& content : _moduleList.list)
+				_processModuleContent(content);
+		}
 	}
 }
 

--- a/tests/cpp/yaramod_tests.cpp
+++ b/tests/cpp/yaramod_tests.cpp
@@ -5,9 +5,11 @@
 */
 
 #include <gtest/gtest.h>
+#include <fstream>
 #include <iostream>
 
 #include "yaramod/types/plain_string.h"
+#include "yaramod/utils/filesystem.h"
 #include "yaramod/yaramod.h"
 
 using namespace ::testing;
@@ -212,6 +214,61 @@ rule rule_with_added_metas
 		true
 }
 )", yarafile->getTextFormatted());
+}
+
+TEST_F(YaramodTests,
+ExclusiveModulePathsLoadsOnlySpecifiedModules) {
+	auto tmpDir = fs::temp_directory_path() / "yaramod_test_exclusive";
+	fs::create_directories(tmpDir);
+	auto moduleFile = tmpDir / "my_time.json";
+
+	{
+		std::ofstream ofs(moduleFile);
+		ofs << R"({
+  "kind": "struct",
+  "name": "time",
+  "attributes": [
+    {
+      "kind": "function",
+      "name": "now",
+      "return_type": "i",
+      "overloads": [
+        {
+          "arguments": [],
+          "documentation": "Returns current time"
+        }
+      ]
+    }
+  ]
+})";
+	}
+
+	yaramod::Yaramod ymod(yaramod::Features::AllCurrent, std::vector<std::string>{moduleFile.string()});
+	auto modules = ymod.getModules();
+
+	EXPECT_EQ(1u, modules.size());
+	EXPECT_TRUE(modules.count("time"));
+	EXPECT_FALSE(modules.count("pe"));
+
+	std::stringstream input;
+	input << R"(import "time"
+rule test {
+	condition:
+		time.now() > 0
+}
+)";
+	auto yarafile = ymod.parseStream(input);
+	ASSERT_NE(nullptr, yarafile);
+	ASSERT_EQ(1u, yarafile->getRules().size());
+
+	fs::remove_all(tmpDir);
+}
+
+TEST_F(YaramodTests,
+ExclusiveModulePathsEmptyListLoadsNoModules) {
+	yaramod::Yaramod ymod(yaramod::Features::AllCurrent, std::vector<std::string>{});
+	auto modules = ymod.getModules();
+	EXPECT_EQ(0u, modules.size());
 }
 
 }

--- a/tests/python/test_modules.py
+++ b/tests/python/test_modules.py
@@ -1,4 +1,6 @@
+import pytest
 import yaramod
+
 
 def test_modules_that_are_readonly(tmp_path):
     modules_directory = tmp_path
@@ -35,3 +37,100 @@ rule test {
 }
 ''')
     assert yfile is not None
+
+
+def _write_time_module(path):
+    path.write_text('''{
+  "kind": "struct",
+  "name": "time",
+  "attributes": [
+    {
+      "kind": "function",
+      "name": "now",
+      "return_type": "i",
+      "overloads": [
+        {
+          "arguments": [],
+          "documentation": "Returns current time as epoch"
+        }
+      ]
+    }
+  ]
+}
+''')
+    return path
+
+
+def test_exclusive_module_paths_loads_only_specified_modules(tmp_path):
+    module_file = _write_time_module(tmp_path / "my_time.json")
+    ymod = yaramod.Yaramod(yaramod.Features.AllCurrent, module_paths=[str(module_file)])
+
+    assert "time" in ymod.modules
+    assert "pe" not in ymod.modules
+    assert "hash" not in ymod.modules
+
+
+def test_exclusive_module_paths_can_parse_rules_with_specified_module(tmp_path):
+    module_file = _write_time_module(tmp_path / "my_time.json")
+    ymod = yaramod.Yaramod(yaramod.Features.AllCurrent, module_paths=[str(module_file)])
+
+    yfile = ymod.parse_string('''import "time"
+rule test {
+    condition:
+        time.now() > 0
+}
+''')
+    assert yfile is not None
+    assert len(yfile.rules) == 1
+
+
+def test_exclusive_module_paths_rejects_unloaded_builtin_module(tmp_path):
+    module_file = _write_time_module(tmp_path / "my_time.json")
+    ymod = yaramod.Yaramod(yaramod.Features.AllCurrent, module_paths=[str(module_file)])
+
+    with pytest.raises(yaramod.ParserError):
+        ymod.parse_string('''import "pe"
+rule test {
+    condition:
+        pe.is_dll()
+}
+''')
+
+
+def test_exclusive_module_paths_empty_list_loads_no_modules():
+    ymod = yaramod.Yaramod(yaramod.Features.AllCurrent, module_paths=[])
+    assert len(ymod.modules) == 0
+
+
+def test_exclusive_module_paths_multiple_modules(tmp_path):
+    time_file = _write_time_module(tmp_path / "my_time.json")
+
+    math_file = tmp_path / "my_math.json"
+    math_file.write_text('''{
+  "kind": "struct",
+  "name": "math",
+  "attributes": [
+    {
+      "kind": "function",
+      "name": "entropy",
+      "return_type": "f",
+      "overloads": [
+        {
+          "arguments": [
+            {"type": "i", "name": "offset"},
+            {"type": "i", "name": "size"}
+          ],
+          "documentation": "Returns entropy"
+        }
+      ]
+    }
+  ]
+}
+''')
+
+    ymod = yaramod.Yaramod(
+        yaramod.Features.AllCurrent,
+        module_paths=[str(time_file), str(math_file)],
+    )
+
+    assert set(ymod.modules.keys()) == {"time", "math"}


### PR DESCRIPTION
Expose the YARAMOD_MODULE_SPEC_PATH_EXCLUSIVE functionality as a proper constructor parameter (vector of JSON file paths) through Yaramod, ParserDriver, and ModulePool. When used, only the specified module files are loaded and built-in modules are skipped.