### PR TITLE
Add exclusive module paths support to YaraFileBuilder

### DIFF
--- a/docs/rtd/getting_started.rst
+++ b/docs/rtd/getting_started.rst
@@ -92,3 +92,22 @@ If you want to use **only** your own module definitions and skip all built-in mo
     );
 
 Passing an empty list creates a ``Yaramod`` instance with no modules at all. This is the programmatic equivalent of setting the ``YARAMOD_MODULE_SPEC_PATH_EXCLUSIVE`` environment variable.
+
+The same API is available on ``YaraFileBuilder`` for programmatic rule construction:
+
+.. code-block:: python
+
+    import yaramod
+
+    builder = yaramod.YaraFileBuilder(
+        yaramod.Features.AllCurrent,
+        module_paths=["/path/to/module_time.json"],
+    )
+
+.. code-block:: cpp
+
+    // C++ equivalent
+    yaramod::YaraFileBuilder builder(
+        yaramod::Features::AllCurrent,
+        std::vector<std::string>{"/path/to/module_time.json"}
+    );

--- a/include/yaramod/builder/yara_file_builder.h
+++ b/include/yaramod/builder/yara_file_builder.h
@@ -43,6 +43,20 @@ public:
 		, _features(features)
 	{
 	}
+	/**
+	 * Constructor with exclusive module paths.
+	 *
+	 * Only modules from the provided file paths are loaded. Built-in modules are skipped.
+	 *
+	 * @param features determines which symbols to import from modules
+	 * @param exclusiveModulePaths paths to JSON files defining modules exclusively
+	 */
+	YaraFileBuilder(Features features, const std::vector<std::string>& exclusiveModulePaths)
+		: _tokenStream(std::make_shared<TokenStream>())
+		, _module_pool(std::make_shared<ModulePool>(features, exclusiveModulePaths))
+		, _features(features)
+	{
+	}
 	/// @}
 
 	/// @name Build method

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -817,6 +817,7 @@ void addBuilderClasses(py::module& module)
 {
 	py::class_<YaraFileBuilder>(module, "YaraFileBuilder")
 		.def(py::init<Features, const std::string&>(), py::arg("import_features") = Features::AllCurrent, py::arg("modules_directory") = "")
+		.def(py::init<Features, const std::vector<std::string>&>(), py::arg("import_features"), py::arg("module_paths"))
 		.def("get", [](YaraFileBuilder& self, bool recheck) {
 				return self.get(recheck, nullptr);
 			}, py::arg("recheck") = false)

--- a/tests/cpp/yaramod_tests.cpp
+++ b/tests/cpp/yaramod_tests.cpp
@@ -271,5 +271,39 @@ ExclusiveModulePathsEmptyListLoadsNoModules) {
 	EXPECT_EQ(0u, modules.size());
 }
 
+TEST_F(YaramodTests,
+YaraFileBuilderExclusiveModulePathsLoadsOnlySpecifiedModules) {
+	auto tmpDir = fs::temp_directory_path() / "yaramod_test_builder_exclusive";
+	fs::create_directories(tmpDir);
+	auto moduleFile = tmpDir / "my_time.json";
+
+	{
+		std::ofstream ofs(moduleFile);
+		ofs << R"({
+  "kind": "struct",
+  "name": "time",
+  "attributes": [
+    {
+      "kind": "function",
+      "name": "now",
+      "return_type": "i",
+      "overloads": [
+        {
+          "arguments": [],
+          "documentation": "Returns current time"
+        }
+      ]
+    }
+  ]
+})";
+	}
+
+	yaramod::YaraFileBuilder builder(yaramod::Features::AllCurrent, std::vector<std::string>{moduleFile.string()});
+	auto yarafile = builder.withModule("time").get(true);
+	ASSERT_NE(nullptr, yarafile);
+
+	fs::remove_all(tmpDir);
+}
+
 }
 }

--- a/tests/python/test_modules.py
+++ b/tests/python/test_modules.py
@@ -134,3 +134,51 @@ def test_exclusive_module_paths_multiple_modules(tmp_path):
     )
 
     assert set(ymod.modules.keys()) == {"time", "math"}
+
+
+def test_yara_file_builder_exclusive_module_paths(tmp_path):
+    module_file = _write_time_module(tmp_path / "my_time.json")
+    builder = yaramod.YaraFileBuilder(
+        yaramod.Features.AllCurrent,
+        module_paths=[str(module_file)],
+    )
+
+    cond = yaramod.bool_val(True)
+    rule = yaramod.YaraRuleBuilder() \
+        .with_name("test") \
+        .with_plain_string("$a", "hello") \
+        .with_condition(cond.get()) \
+        .get()
+
+    file = builder \
+        .with_module("time") \
+        .with_rule(rule) \
+        .get(recheck=True)
+
+    assert file is not None
+    assert len(file.rules) == 1
+
+
+def test_yara_file_builder_exclusive_module_paths_ignores_unloaded(tmp_path):
+    """When using exclusive module_paths, adding a module that isn't loaded
+    silently drops it — the import does not appear in the output."""
+    module_file = _write_time_module(tmp_path / "my_time.json")
+    builder = yaramod.YaraFileBuilder(
+        yaramod.Features.AllCurrent,
+        module_paths=[str(module_file)],
+    )
+
+    cond = yaramod.bool_val(True)
+    rule = yaramod.YaraRuleBuilder() \
+        .with_name("test") \
+        .with_plain_string("$a", "hello") \
+        .with_condition(cond.get()) \
+        .get()
+
+    file = builder \
+        .with_module("pe") \
+        .with_rule(rule) \
+        .get(recheck=True)
+
+    assert file is not None
+    assert 'import "pe"' not in file.text


### PR DESCRIPTION
Extends YaraFileBuilder with a constructor that accepts explicit JSON module file paths, skipping built-in modules — matching the API already available on the Yaramod class since v4.7.0.