### PR TITLE
fix: hex strings misparsed after non-string meta values

### DIFF
--- a/src/parser/parser_driver.cpp
+++ b/src/parser/parser_driver.cpp
@@ -233,8 +233,8 @@ void ParserDriver::defineTokens()
 	});
 
 	// Exit meta state when encountering section keywords or rule end
-	_parser.token("strings").states("$meta").enter_state("@default").symbol("STRINGS").description("strings").action([&](std::string_view str) -> Value { return emplace_back(TokenType::STRINGS, std::string{str}); });
-	_parser.token("condition").states("$meta").enter_state("@default").symbol("CONDITION").description("condition").action([&](std::string_view str) -> Value { return emplace_back(TokenType::CONDITION, std::string{str}); });
+	_parser.token("strings").states("$meta").enter_state("@default").symbol("STRINGS").description("strings").action([&](std::string_view str) -> Value { sectionStrings(true); return emplace_back(TokenType::STRINGS, std::string{str}); });
+	_parser.token("condition").states("$meta").enter_state("@default").symbol("CONDITION").description("condition").action([&](std::string_view str) -> Value { sectionStrings(false); return emplace_back(TokenType::CONDITION, std::string{str}); });
 	_parser.token("variables").states("$meta").enter_state("@default").symbol("VARIABLES").description("variables").action([&](std::string_view str) -> Value { return emplace_back(TokenType::VARIABLES, std::string{str}); });
 	_parser.token("\\}").states("$meta").enter_state("@default").symbol("RCB").description("}").action([&](std::string_view str) -> Value { return emplace_back(TokenType::RCB, std::string{str}); });
 

--- a/tests/cpp/parser_tests.cpp
+++ b/tests/cpp/parser_tests.cpp
@@ -247,6 +247,47 @@ rule hex_and_decimal_integers_are_preserved
 }
 
 TEST_F(ParserTests,
+HexStringAfterNonStringMetaWorks) {
+	// Regression: when a meta section ends with a non-string value (integer
+	// or boolean), the lexer must still switch to the hex string state for a
+	// following strings section. Otherwise the leading hex nibbles are lexed
+	// as an integer and parsing fails.
+	prepareInput(
+R"(
+rule hex_string_after_non_string_meta
+{
+	meta:
+		third_party = false
+		rule_version = 1
+	strings:
+		$h = { 48 81 04 24 ?? ?? 00 00 E9 }
+	condition:
+		$h
+}
+)");
+
+	EXPECT_TRUE(driver.parse(input));
+	ASSERT_EQ(1u, driver.getParsedFile().getRules().size());
+
+	const auto& rule = driver.getParsedFile().getRules()[0];
+	EXPECT_EQ("hex_string_after_non_string_meta", rule->getName());
+
+	ASSERT_EQ(2u, rule->getMetas().size());
+	EXPECT_TRUE(rule->getMetas()[0].getValue().isBool());
+	EXPECT_TRUE(rule->getMetas()[1].getValue().isInt());
+
+	auto strings = rule->getStrings();
+	ASSERT_EQ(1u, strings.size());
+
+	auto hexString = strings[0];
+	EXPECT_TRUE(hexString->isHex());
+	EXPECT_EQ("$h", hexString->getIdentifier());
+	EXPECT_EQ("{ 48 81 04 24 ?? ?? 00 00 E9 }", hexString->getText());
+
+	EXPECT_EQ(input_text, driver.getParsedFile().getTextFormatted());
+}
+
+TEST_F(ParserTests,
 RuleWithVariablesWorks) {
 	prepareInput(
 R"(

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -73,6 +73,34 @@ rule rule_with_metas {
         self.assertTrue(rule.metas[2].value.is_bool)
         self.assertEqual(rule.metas[2].value.text, 'true')
 
+    def test_hex_string_after_non_string_meta(self):
+        # Regression: a meta section ending with a non-string value (integer
+        # or boolean) must not prevent a following hex string from being
+        # lexed correctly.
+        yara_file = yaramod.Yaramod().parse_string('''
+rule hex_string_after_non_string_meta {
+    meta:
+        third_party = false
+        rule_version = 1
+    strings:
+        $h = { 48 81 04 24 ?? ?? 00 00 E9 }
+    condition:
+        $h
+}''')
+
+        self.assertEqual(len(yara_file.rules), 1)
+
+        rule = yara_file.rules[0]
+        self.assertEqual(rule.name, 'hex_string_after_non_string_meta')
+        self.assertEqual(len(rule.metas), 2)
+        self.assertTrue(rule.metas[0].value.is_bool)
+        self.assertTrue(rule.metas[1].value.is_int)
+
+        self.assertEqual(len(rule.strings), 1)
+        self.assertEqual(rule.strings[0].identifier, '$h')
+        self.assertTrue(rule.strings[0].is_hex)
+        self.assertEqual(rule.strings[0].text, '{ 48 81 04 24 ?? ?? 00 00 E9 }')
+
     def test_add_meta(self):
         yara_file = yaramod.Yaramod().parse_string('''
 rule rule_with_added_metas {


### PR DESCRIPTION
When the last value in a meta: section was an integer or boolean, the lexer stayed in the $meta state at the strings keyword. The $meta-state strings token transitioned back to @default but, unlike its @default counterpart, never set sectionStrings(true) -- so a following { was not recognized as a hex string opener and its nibbles were lexed as integers, causing a ParserError. A trailing string meta value masked the bug because the closing quote already returns the lexer to @default.

Also sets sectionStrings(false) on the $meta-state condition token to mirror the @default counterpart. Adds C++ and Python regression tests.